### PR TITLE
Reproduce

### DIFF
--- a/bin/cij_runner
+++ b/bin/cij_runner
@@ -6,6 +6,8 @@ import argparse
 import uuid
 import sys
 import os
+import glob
+import datetime
 import cij.runner
 import cij.util
 import cij
@@ -63,6 +65,19 @@ def main():
 
     # Setup path to testplan
     conf["TESTPLAN_FPATH"] = cij.util.expand_path(conf["TESTPLAN"])
+
+    if os.path.isdir(conf["TESTPLAN_FPATH"]):
+        conf["OUTPUT"] = \
+        conf["TESTPLAN_FPATH"] + "/reproduce-" + \
+        datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+
+        conf["TESTPLAN_FPATH"] = glob.glob(conf["TESTPLAN_FPATH"] + "/*.plan")
+        if not conf["TESTPLAN_FPATH"]:
+            cij.err("REPRODUCE: not valid result folder")
+            return 1
+
+        conf["TESTPLAN_FPATH"] = conf["TESTPLAN_FPATH"][0]
+
     if not os.path.exists(conf["TESTPLAN_FPATH"]):
         cij.err("TESTPLAN_FPATH: %r, does not exist" % conf["TESTPLAN_FPATH"])
         return 1

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,7 +16,7 @@ configure: clean
 
 .PHONY: kmdo
 kmdo:
-	kmdo src
+	kmdo src || exit 0
 
 .PHONY: sphinx
 sphinx:
@@ -30,4 +30,4 @@ doc: clean deps configure kmdo sphinx
 
 .PHONY: doc-view-html
 doc-view-html:
-	xdg-open $(BUILD_DIR)/html/index.html &
+	(xdg-open $(BUILD_DIR)/html/index.html || open $(BUILD_DIR)/html/index.html) &

--- a/docs/src/quickstart.rst
+++ b/docs/src/quickstart.rst
@@ -74,6 +74,17 @@ Invoke the test runner, generate report and inspect the result:
   # Inspect the test-report
   xdg-open $RESULTS/report.html
 
+Reproduce
+=========
+
+After running a testplan, you can reproduce it on a different environment. Just
+pass a result directory instead of a testplan.
+
+.. code-block:: bash
+
+  cij_runner $RESULTS new_target_env.sh
+
+
 Python Version
 ==============
 

--- a/modules/cij/runner.py
+++ b/modules/cij/runner.py
@@ -597,6 +597,10 @@ def trun_setup(conf):
     trun["aux_root"] = os.sep.join([trun["res_root"], "_aux"])
     trun["evars"].update(copy.deepcopy(declr.get("evars", {})))
 
+    shutil.copyfile(
+	conf["TESTPLAN_FPATH"],
+	conf["OUTPUT"] + "/" + conf["TESTPLAN_FNAME"]
+    )
     os.makedirs(trun["aux_root"])
 
     hook_names = declr.get("hooks", [])

--- a/selftest.sh
+++ b/selftest.sh
@@ -72,8 +72,8 @@ main() {
   fi
 
   if [[ $open_reports -gt 0 ]]; then
-    xdg-open "$res_dpath/testcases.html" &
-    xdg-open "$res_dpath/report.html" &
+    (xdg-open "$res_dpath/testcases.html" || open "$res_dpath/testcases.html") &
+    (xdg-open "$res_dpath/report.html" || open "$res_dpath/report.html") &
   fi
 
   cij::info "res: '$res'"


### PR DESCRIPTION
This is a very early first iteration of the reproduce feature. After completing a test run you can call `cij_bundle` on the path, which will create a `.cijoe` file in the current working directory. Move this to the new environment and call `cij_reproduce` on the file. This will create a temporary path, where the test plan is rerun. After running it will print out the number of passed, failed and unknowns. When the metric parser is complete I suggest that those numbers will be shown in the print as well.