### PR TITLE
Initial Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:alpine
+
+# Install build essentials, bash and ssh
+RUN apk add alpine-sdk bash openssh-client
+
+# Create a results volume
+VOLUME /results
+
+# Force mktemp to store results in the volume
+RUN echo 'alias mktemp="mktemp -p /results -t XXXXXX"' >> ~/.bashrc
+
+# copy cijoe to container
+COPY . /cijoe
+WORKDIR /cijoe
+
+# Build cijoe
+RUN make install-system
+
+ENTRYPOINT ["cijoe"]

--- a/bin/cijoe
+++ b/bin/cijoe
@@ -47,6 +47,14 @@ if [[ ! -f "$ENV_FPATH" ]]; then
 		exit
 	fi
 fi
+
+# check if we are in docker
+if [ -f /.dockerenv ]; then
+    cp -R /tmp/cijoe/.ssh /root/.ssh
+    chmod 700 /root/.ssh
+    chmod 600 /root/.ssh/*
+fi
+
 # shellcheck disable=SC2016
 bash --rcfile <(echo '[[ -f ~/.bashrc ]] && . ~/.bashrc; source modules/cijoe.sh; cd '"$HERE"'; export PS1="[cijoe:'"$ENV_NAME"'] $PS1"; source '"$ENV_FPATH"'; cij::emph "Welcome to CIJOE ENV_FPATH: '"$ENV_FPATH"'"; ')
 

--- a/docs/src/docker.rst
+++ b/docs/src/docker.rst
@@ -1,0 +1,56 @@
+=============
+ Docker
+=============
+
+**cijoe** can run in docker. First, pull the docker image from DockerHub or
+build it yourself.
+
+.. code-block:: bash
+
+  # Pull cijoe image
+  docker pull cijoe/cijoe
+
+.. code-block:: bash
+
+  # Build it yourself
+  docker build . -t cijoe/cijoe
+
+.. note:: **cijoe** will force the **mktemp** command to create temporary
+  directories in the /results folder. This allows for easy extraction of test
+  results, but may cause issues if your application relies on **mktemp**. We
+  will resolve this issue in a future release.
+
+You can now start the docker container and run a testplan. To make running
+testplans easier, you can link your target environment and results folder.
+
+.. code-block:: bash
+
+  # Run cijoe
+  docker run -it \
+  -v $(pwd)/target_env.sh:/cijoe/target_env.sh \
+  -v $(pwd)/results:/results \
+  cijoe/cijoe
+
+You can now run your testplan. See `QuickStart`_ for examples on how to use
+**cijoe**. Starting the docker container is equivalent to running the **cijoe**
+command.
+
+.. note:: If you run **cijoe** tests on a remote system, bear in mind that you
+  may need to transfer or link the SSH keys to the container. **cijoe** will
+  make sure your keys are available in the docker container, if you mount your
+  SSH folder in /tmp/cijoe/.ssh.
+
+.. warning:: Linking SSH keys to the container gives any software running in
+  the container full read access to the private keys. Do not do this if cijoe is
+  running untrusted code.
+
+.. code-block:: bash
+
+  # Run cijoe with same key as the host
+  docker run -it \
+  -v $(pwd)/target_env.sh:/cijoe/target_env.sh \
+  -v $(pwd)/results:/results \
+  -v ~/.ssh:/tmp/cijoe/.ssh:ro \
+  cijoe/cijoe
+
+.. _Quickstart: https://cijoe.readthedocs.io/en/latest/quickstart.html#usage

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -9,6 +9,7 @@ Contents:
    :includehidden:
 
    quickstart.rst
+   docker.rst
    envs.rst
    packages.rst
 
@@ -18,4 +19,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-


### PR DESCRIPTION
The Dockerfile will create a docker container that is equivalent to running the _cijoe_ command. I have created a docker repo on [DockerHub](https://hub.docker.com/repository/docker/cijoe/cijoe). We should setup travis to push to there when releases are created.