### PR TITLE
ci: change from ubuntu latest to explicitly testing 20.04 and 18.04

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
 
     steps:


### PR DESCRIPTION
Checking to see the effect on shellcheck