### PR TITLE
Makeover fixes

### DIFF
--- a/modules/cij.sh
+++ b/modules/cij.sh
@@ -193,3 +193,63 @@ cij::isint() {
   [[ "$1" =~ ^[0-9]+$ ]]
   return $?
 }
+
+#
+# Transform files from cijoe-local storage to target
+#
+cij::push() {
+  local _src=$1
+  local _dst=$2
+
+  if [[ ! -v _src ]]; then
+    cij::err "cij.push: missing first argument (src)"
+    return 1
+  fi
+  if [[ ! -v _dst ]]; then
+    cij::err "cij.push: missing second argument (dst)"
+    return 1
+  fi
+
+  if [[ -v CIJ_TARGET_TRANSPORT && "${CIJ_TARGET_TRANSPORT}" == "ssh" ]] || [[ -v SSH_HOST ]]; then
+    ssh::push "${_src}" "${_dst}"
+    return $?
+  else
+    cp -r "${_src}" "${_dst}"
+    return $?
+  fi
+}
+
+#
+# Transform files from target to cijoe-local storage
+#
+cij::pull() {
+  local _src=$1
+  local _dst=$2
+
+  if [[ ! -v _src ]]; then
+    cij::err "cij.pull: missing first argument (src)"
+    return 1
+  fi
+  if [[ ! -v _dst ]]; then
+    cij::err "cij.pull: missing second argument (dst)"
+    return 1
+  fi
+
+  if [[ -v CIJ_TARGET_TRANSPORT && "${CIJ_TARGET_TRANSPORT}" == "ssh" ]] || [[ -v SSH_HOST ]]; then
+    ssh::pull "${_src}" "${_dst}"
+    return $?
+  else
+    cp -r "${_src}" "${_dst}"
+    return $?
+  fi
+}
+
+cij::cmd() {
+  if [[ -v CIJ_TARGET_TRANSPORT && "${CIJ_TARGET_TRANSPORT}" == "ssh" ]] || [[ -v SSH_HOST ]]; then
+    ssh::cmd "$@"
+    return $?
+  else
+    "$@"
+    return $?
+  fi
+}

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -102,6 +102,7 @@ ssh::cmd() {
   fi
 
   eval "$_cmd"                                                  # Execute CMD
+  return $?
 }
 
 ssh::cmd_output() {


### PR DESCRIPTION
A fix to the ``ssh:cmd`` and addition an addition of ``cij::cmd``.
The point of ``cij::cmd`` is to provide a helper in testcases for the actual command-invocation, such that one does write ``ssh::cmd`` directly in the testcase but rather via ``cij::cmd`` instead, ``cij::cmd`` then invokes the command via a transport such as SSH or via local command execution. It is in preparation for fixing up that lack on indirection but added now such that new examples can use it.