### PR TITLE
Support for multiple testplans per testrun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Sections with "(Upcoming)" describe changes on the roadmap for CIJOE.
 Changes on the `master` branch, from the latest version tag up to and including
 HEAD can be subject to a git rebase.
 
+## 0.1.42
+
+* Support for multiple testplans per test-run
+  - Arguments to ``cij_runner`` has changed
+    Use: ``--testplan`` to provide one or more testplans (this replaces positional arg)
+    Use: ``--env`` to provide invironment file (this replaces positional arg)
+  - Structure of ``cij_runner`` output has changed
+    Before: ``<OUTPUT>/testsuite_ident/...``
+    Now: ``<OUTPUT>/testplan_ident/testsuite_ident/...``
+    In other words, testsuites and nested beneath testplans in the test-result output.
+
 ## 0.0.35
 
 * Added option tot disable colors in bash-output-helpers

--- a/bin/cij_fetch
+++ b/bin/cij_fetch
@@ -148,7 +148,7 @@ def main(args):
     url_parts = urlparse.urlparse(args.url)
     url_path = url_parts.path
 
-    local_path = os.path.normpath(os.sep.join([args.root, url_path]))
+    local_path = os.path.normpath(os.path.join(args.root, url_path))
 
     if reservoir_to_file(url, local_path):
         sys.exit(0)

--- a/bin/cij_reporter
+++ b/bin/cij_reporter
@@ -37,7 +37,7 @@ def parse_args():
     prsr.add_argument(
         '--template',
         help="Path to report template",
-        default=os.sep.join([cij_evars["TEMPLATES"], "report.html"])
+        default=os.path.join(cij_evars["TEMPLATES"], "report.html")
     )
     prsr.add_argument(
         '--force',

--- a/bin/cij_runner
+++ b/bin/cij_runner
@@ -19,12 +19,18 @@ def parse_args():
         description="cij_runner - CIJOE Test Runner",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
+    prsr.register('action', 'custom_extend', cij.util.ExtendAction)
     prsr.add_argument(
-        "testplan",
-        help="Path to the testplan to run",
+        "--testplan",
+        help="Path to one or more testplan(s) to run",
+        action="custom_extend",
+        nargs="+",
+        required=True,
+        type=str
     )
     prsr.add_argument(
-        "env",
+        "--env",
+        required=True,
         help="Path to the environment definition",
     )
     prsr.add_argument(
@@ -67,14 +73,17 @@ def main():
     conf = {}
     conf.update(evars)
     conf.update(args)
+    conf["TP_FPATH"] = []
 
-    # Setup path to testplan
-    conf["TESTPLAN_FPATH"] = cij.util.expand_path(conf["TESTPLAN"])
-    if not os.path.exists(conf["TESTPLAN_FPATH"]):
-        cij.err("TESTPLAN_FPATH: %r, does not exist" % conf["TESTPLAN_FPATH"])
-        return 1
-    conf["TESTPLAN_FNAME"] = os.path.basename(conf["TESTPLAN_FPATH"])
-    conf["TESTPLAN_NAME"] = ".".join(conf["TESTPLAN_FNAME"].split(".")[:-1])
+    # Setup tplan filepaths
+    for path in conf["TESTPLAN"]:
+        tplan_fpath = cij.util.expand_path(path)
+
+        if not os.path.exists(tplan_fpath):
+            cij.err("TESTPLAN_FPATH: %r, does not exist" % tplan_fpath)
+            return 1
+
+        conf["TP_FPATH"].append(tplan_fpath)
 
     # Setup path to env script
     conf["ENV_FPATH"] = cij.util.expand_path(conf["ENV"])

--- a/bin/cij_runner
+++ b/bin/cij_runner
@@ -36,10 +36,7 @@ def parse_args():
     prsr.add_argument(
         "--output",
         help="Path to directory in which to store runner output",
-        default=os.sep.join([
-            "/tmp",
-            "trun-%s" % str(uuid.uuid4())[:8]
-        ])
+        default=os.path.join("/tmp", "trun-%s" % str(uuid.uuid4())[:8])
     )
     prsr.add_argument(
         "--testcase-match",

--- a/bin/cij_testcases
+++ b/bin/cij_testcases
@@ -29,7 +29,7 @@ def construct_dset(evars):
             dset[group] = []
             dset["group_names"].append(group)
 
-        fpath = os.sep.join([evars["TESTCASES"], fname])
+        fpath = os.path.join(evars["TESTCASES"], fname)
 
         tcase = TestCase(
             fpath=fpath,
@@ -72,7 +72,7 @@ def parse_args():
     prsr.add_argument(
         '--template',
         help="Path to template",
-        default=os.sep.join([evars["TEMPLATES"], "testcases.html"])
+        default=os.path.join(evars["TEMPLATES"], "testcases.html")
     )
     prsr.add_argument(
         '--output',
@@ -93,7 +93,7 @@ def parse_args():
 def main(args, evars):
     """Main entry point"""
 
-    html_fpath = os.sep.join([args.output, "testcases.html"])
+    html_fpath = os.path.join(args.output, "testcases.html")
 
     cij.emph("html_fpath: %r" % html_fpath)
 

--- a/bin/cij_tlint
+++ b/bin/cij_tlint
@@ -26,7 +26,7 @@ def _load_tplans(ident, roots, fnames):
     violations = []
 
     for tp_fname in fnames["TPLANS"]:
-        tp_fpath = os.sep.join([roots["TPLANS"], tp_fname])
+        tp_fpath = os.path.join(roots["TPLANS"], tp_fname)
 
         tplan = None
         try:
@@ -59,7 +59,7 @@ def tsuitefile_testcases_exists(ident, roots, fnames):
     violations = []
 
     for ts_fname in fnames["TSUITES"]:    # Search .suite files
-        ts_fpath = os.sep.join([roots["TSUITES"], ts_fname])
+        ts_fpath = os.path.join(roots["TSUITES"], ts_fname)
         with open(ts_fpath) as tsfd:
             ts_lines_all = (
                 line.strip() for line in tsfd.read().splitlines()
@@ -88,7 +88,7 @@ def testcase_unused(ident, roots, fnames):
     tcases_in_use = set([])
 
     for ts_fname in fnames["TSUITES"]:  # Testcases from suite-files
-        ts_fpath = os.sep.join([roots["TSUITES"], ts_fname])
+        ts_fpath = os.path.join(roots["TSUITES"], ts_fname)
         with open(ts_fpath) as tsfd:
             ts_lines_all = (
                 line.strip() for line in tsfd.read().splitlines()
@@ -288,10 +288,10 @@ if __name__ == "__main__":
     ARGS = PRSR.parse_args()
 
     ROOTS = {
-        "TPLANS": os.sep.join([CIJ_ROOT, "testplans"]),
-        "TSUITES": os.sep.join([CIJ_ROOT, "testsuites"]),
-        "TCASES": os.sep.join([CIJ_ROOT, "testcases"]),
-        "HOOKS": os.sep.join([CIJ_ROOT, "hooks"])
+        "TPLANS": os.path.join(CIJ_ROOT, "testplans"),
+        "TSUITES": os.path.join(CIJ_ROOT, "testsuites"),
+        "TCASES": os.path.join(CIJ_ROOT, "testcases"),
+        "HOOKS": os.path.join(CIJ_ROOT, "hooks")
     }
 
     sys.exit(main(ROOTS))

--- a/modules/cij/reporter.py
+++ b/modules/cij/reporter.py
@@ -101,7 +101,7 @@ def runlogs_to_html(run_root):
     hook_enter = []
     hook_exit = []
     tcase = []
-    for fpath in glob.glob(os.sep.join([run_root, "*.log"])):
+    for fpath in glob.glob(os.path.join(run_root, "*.log")):
         if "exit" in fpath:
             hook_exit.append(fpath)
             continue
@@ -279,7 +279,7 @@ def main(args):
     cij.emph("main: reports are uses tmpl_fpath: %r" % args.tmpl_fpath)
     cij.emph("main: reports are here args.output: %r" % args.output)
 
-    html_fpath = os.sep.join([args.output, "%s.html" % args.tmpl_name])
+    html_fpath = os.path.join(args.output, "%s.html" % args.tmpl_name)
     cij.emph("html_fpath: %r" % html_fpath)
     try:                                    # Create and store HTML report
         with open(html_fpath, 'w') as html_file:

--- a/modules/cij/reporter.py
+++ b/modules/cij/reporter.py
@@ -174,12 +174,21 @@ def process_tcase(tcase):
     return True
 
 
+def process_tplan(tplan):
+    """Goes through the tplan and processes "run.log" """
+
+    tplan.log_content = runlogs_to_html(tplan.res_root)
+    tplan.aux_list = aux_listing(tplan.aux_root)
+    tplan.hnames = extract_hook_names(tplan)
+
+    return True
+
+
 def process_trun(trun):
     """Goes through the trun and processes "run.log" """
 
     trun.log_content = runlogs_to_html(trun.res_root)
     trun.aux_list = aux_listing(trun.aux_root)
-    trun.hnames = extract_hook_names(trun)
 
     return True
 
@@ -190,11 +199,12 @@ def postprocess(trun):
     plog = []
     plog.append(("trun", process_trun(trun)))
 
-    for tsuite in trun.testsuites:
-        plog.append(("tsuite", process_tsuite(tsuite)))
+    for tplan in trun.testplans:
+        for tsuite in tplan.testsuites:
+            plog.append(("tsuite", process_tsuite(tsuite)))
 
-        for tcase in tsuite.testcases:
-            plog.append(("tcase", process_tcase(tcase)))
+            for tcase in tsuite.testcases:
+                plog.append(("tcase", process_tcase(tcase)))
 
     for task, success in plog:
         if not success:

--- a/modules/cij/runner.py
+++ b/modules/cij/runner.py
@@ -793,7 +793,7 @@ def main(conf):
 
             for tcase in (tc for tc in tsuite.testcases if tsuite.entered):
                 tcase_match = conf.get("TESTCASE_MATCH", None)
-                if not (tcase_match and tcase_match not in tcase.name):
+                if tcase_match is None or tcase_match in tcase.name:
                     tcase.enter(trun)
                     if tcase.entered:
                         script_run(trun, tcase)

--- a/modules/cij/runner.py
+++ b/modules/cij/runner.py
@@ -256,7 +256,7 @@ def junit_fpath(output_path):
     return os.sep.join([output_path, "trun.xml"])
 
 
-def script_run(trun, script: Runnable):
+def script_run(trun: TestRun, script: Runnable):
     """Execute a script or testcase"""
 
     if trun.conf["VERBOSE"]:
@@ -342,7 +342,7 @@ def hook_setup(parent, hook_fpath) -> Hook:
     return hook
 
 
-def hooks_setup(trun, parent, hnames=None) -> Dict[str, List[Hook]]:
+def hooks_setup(trun: TestRun, parent, hnames=None) -> Dict[str, List[Hook]]:
     """
     Setup test-hooks
     @returns dict of hook filepaths {"enter": [], "exit": []}
@@ -374,7 +374,7 @@ def hooks_setup(trun, parent, hnames=None) -> Dict[str, List[Hook]]:
     return hooks
 
 
-def trun_to_file(trun, fpath=None):
+def trun_to_file(trun: TestRun, fpath=None):
     """Dump the given trun to file"""
 
     if fpath is None:
@@ -388,7 +388,7 @@ def trun_to_file(trun, fpath=None):
         yml_file.write(data)
 
 
-def trun_to_junitfile(trun, fpath=None):
+def trun_to_junitfile(trun: TestRun, fpath=None) -> int:
     """Generate jUNIT XML from testrun YML"""
 
     try:
@@ -464,7 +464,7 @@ def trun_to_junitfile(trun, fpath=None):
     return 0
 
 
-def trun_from_file(fpath):
+def trun_from_file(fpath) -> TestRun:
     """Returns trun from the given fpath"""
 
     with open(fpath, 'r') as yml_file:
@@ -472,7 +472,7 @@ def trun_from_file(fpath):
         return TestRun.from_dict(trun_dict)
 
 
-def trun_emph(trun):
+def trun_emph(trun: TestRun):
     """Print essential info on"""
 
     if trun.conf["VERBOSE"] > 1:               # Print environment variables
@@ -488,7 +488,7 @@ def trun_emph(trun):
         cij.emph("}")
 
 
-def tcase_setup(trun, parent, tcase_fname) -> TestCase:
+def tcase_setup(trun: TestRun, parent, tcase_fname) -> TestCase:
     """
     Create and initialize a testcase
     """
@@ -527,7 +527,7 @@ def tcase_setup(trun, parent, tcase_fname) -> TestCase:
     return case
 
 
-def tsuite_exit(trun, tsuite):
+def tsuite_exit(trun: TestRun, tsuite: TestSuite) -> int:
     """Triggers when exiting the given testsuite"""
 
     if trun.conf["VERBOSE"]:
@@ -545,7 +545,7 @@ def tsuite_exit(trun, tsuite):
     return rcode
 
 
-def tsuite_enter(trun, tsuite):
+def tsuite_enter(trun: TestRun, tsuite: TestSuite) -> int:
     """Triggers when entering the given testsuite"""
 
     if trun.conf["VERBOSE"]:
@@ -563,7 +563,7 @@ def tsuite_enter(trun, tsuite):
     return rcode
 
 
-def tsuite_setup(trun, declr, enum) -> TestSuite:
+def tsuite_setup(trun: TestRun, declr, enum) -> TestSuite:
     """
     Creates and initialized a TESTSUITE struct and site-effects such as
     creating output directories and forwarding initialization of testcases
@@ -628,7 +628,7 @@ def tsuite_setup(trun, declr, enum) -> TestSuite:
     return suite
 
 
-def tcase_exit(trun, tsuite, tcase):
+def tcase_exit(trun: TestRun, tsuite: TestSuite, tcase: TestCase) -> int:
     """..."""
     # pylint: disable=locally-disabled, unused-argument
 
@@ -647,7 +647,7 @@ def tcase_exit(trun, tsuite, tcase):
     return rcode
 
 
-def tcase_enter(trun, tsuite, tcase):
+def tcase_enter(trun: TestRun, tsuite: TestSuite, tcase: TestCase) -> int:
     """
     setup res_root and aux_root, log info and run tcase-enter-hooks
 
@@ -672,7 +672,7 @@ def tcase_enter(trun, tsuite, tcase):
     return rcode
 
 
-def trun_exit(trun):
+def trun_exit(trun: TestRun) -> int:
     """Triggers when exiting the given testrun"""
 
     if trun.conf["VERBOSE"]:
@@ -690,7 +690,7 @@ def trun_exit(trun):
     return rcode
 
 
-def trun_enter(trun):
+def trun_enter(trun: TestRun) -> int:
     """Triggers when entering the given testrun"""
 
     if trun.conf["VERBOSE"]:

--- a/modules/cij/runner.py
+++ b/modules/cij/runner.py
@@ -190,6 +190,8 @@ class TestRun:
 
     ver: str = ""
     conf: dict = dataclasses.field(default_factory=dict)
+
+    counter: int = 0
     evars: dict = dataclasses.field(default_factory=dict)
     progress: dict = dataclasses.field(default_factory=lambda: {
         Status.Pass: 0,
@@ -215,6 +217,13 @@ class TestRun:
     wallc: Optional[float] = None
     log_content: str = ""
     hnames: list = dataclasses.field(default_factory=list)
+
+    def inc(self):
+        """Increment and return counter"""
+
+        self.counter += 1
+
+        return self.counter
 
     @staticmethod
     def from_dict(trun_dict) -> TestRun:

--- a/modules/cij/runner.py
+++ b/modules/cij/runner.py
@@ -44,9 +44,9 @@ class Runnable:
     """
     name: str = "UNNAMED"
     evars: dict = dataclasses.field(default_factory=dict)
-    log_fpath: str = ""
-    fpath: str = ""
-    res_root: str = ""
+    res_root: str = ""              # Abs. path to result directory
+    fpath: str = ""                 # Abs. path to script / suite /  plan
+    log_fpath: str = ""             # Abs. path to run.log
     rcode: Optional[int] = None
     wallc: Optional[float] = None
 

--- a/modules/cij/runner.py
+++ b/modules/cij/runner.py
@@ -336,13 +336,13 @@ class InitializationError(Exception):
 def yml_fpath(output_path):
     """Returns the path to the trun YAML-file"""
 
-    return os.sep.join([output_path, "trun.yml"])
+    return os.path.join(output_path, "trun.yml")
 
 
 def junit_fpath(output_path):
     """Returns the path to the jUNIT XML-file"""
 
-    return os.sep.join([output_path, "trun.xml"])
+    return os.path.join(output_path, "trun.xml")
 
 
 def script_run(trun: TestRun, script: Runnable):
@@ -422,11 +422,8 @@ def hook_setup(parent, hook_fpath) -> Hook:
     hook.res_root = parent.res_root
     hook.fpath_orig = hook_fpath
     hook.fname = "hook_%s" % os.path.basename(hook.fpath_orig)
-    hook.fpath = os.sep.join([hook.res_root, hook.fname])
-    hook.log_fpath = os.sep.join([
-        hook.res_root,
-        "%s.log" % hook.fname
-    ])
+    hook.fpath = os.path.join(hook.res_root, hook.fname)
+    hook.log_fpath = os.path.join(hook.res_root, "%s.log" % hook.fname)
 
     hook.evars.update(copy.deepcopy(parent.evars))
 
@@ -452,7 +449,7 @@ def hooks_setup(trun: TestRun, parent, hnames=None) -> Dict[str, List[Hook]]:
     for hname in hnames:      # Fill out paths
         for med in HOOK_PATTERNS:
             for ptn in HOOK_PATTERNS[med]:
-                fpath = os.sep.join([trun.conf["HOOKS"], ptn % hname])
+                fpath = os.path.join(trun.conf["HOOKS"], ptn % hname)
                 if not os.path.exists(fpath):
                     continue
 
@@ -591,7 +588,7 @@ def tcase_setup(trun: TestRun, parent, tcase_fname) -> TestCase:
     case = TestCase()
 
     case.fname = tcase_fname
-    case.fpath_orig = os.sep.join([trun.conf["TESTCASES"], case.fname])
+    case.fpath_orig = os.path.join(trun.conf["TESTCASES"], case.fname)
 
     if not os.path.exists(case.fpath_orig):
         msg = ("rnr:tcase_setup: file case.fpath_orig does not exist: "
@@ -602,11 +599,11 @@ def tcase_setup(trun: TestRun, parent, tcase_fname) -> TestCase:
     case.name = os.path.splitext(case.fname)[0]
     case.ident = "/".join([parent.ident, case.fname])
 
-    case.res_root = os.sep.join([parent.res_root, case.fname])
-    case.aux_root = os.sep.join([case.res_root, "_aux"])
-    case.log_fpath = os.sep.join([case.res_root, "run.log"])
+    case.res_root = os.path.join(parent.res_root, case.fname)
+    case.aux_root = os.path.join(case.res_root, "_aux")
+    case.log_fpath = os.path.join(case.res_root, "run.log")
 
-    case.fpath = os.sep.join([case.res_root, case.fname])
+    case.fpath = os.path.join(case.res_root, case.fname)
 
     case.evars.update(copy.deepcopy(parent.evars))
 
@@ -638,7 +635,7 @@ def tsuite_setup(trun: TestRun, tplan: TestPlan, declr, enum) -> TestSuite:
     suite.ident = "%s_%d" % (suite.name, enum)
 
     suite.res_root = os.path.join(tplan.res_root, suite.ident)
-    suite.aux_root = os.sep.join([suite.res_root, "_aux"])
+    suite.aux_root = os.path.join(suite.res_root, "_aux")
 
     suite.evars.update(copy.deepcopy(tplan.evars))
     suite.evars.update(copy.deepcopy(declr.get("evars", {})))
@@ -654,7 +651,7 @@ def tsuite_setup(trun: TestRun, tplan: TestPlan, declr, enum) -> TestSuite:
     suite.hooks_pr_tcase = declr.get("hooks_pr_tcase", [])
 
     suite.fname = "%s.suite" % suite.name
-    suite.fpath = os.sep.join([trun.conf["TESTSUITES"], suite.fname])
+    suite.fpath = os.path.join(trun.conf["TESTSUITES"], suite.fname)
 
     #
     # Load testcases from .suite file OR from declaration
@@ -753,7 +750,7 @@ def trun_setup(conf) -> TestRun:
     trun.ident = trun.name
 
     trun.res_root = conf["OUTPUT"]
-    trun.aux_root = os.sep.join([trun.res_root, "_aux"])
+    trun.aux_root = os.path.join(trun.res_root, "_aux")
 
     os.makedirs(trun.aux_root)
 

--- a/modules/cij/util.py
+++ b/modules/cij/util.py
@@ -3,9 +3,20 @@
 """
 from __future__ import print_function
 from subprocess import Popen, PIPE
+import argparse
 import os
 import re
 import cij
+
+
+class ExtendAction(argparse.Action):
+    """Custom action, since the extend-action is not available until 3.8"""
+
+    # pylint: disable=too-few-public-methods
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = getattr(namespace, self.dest) or []
+        items.extend(values)
+        setattr(namespace, self.dest, items)
 
 
 def expand_path(path):

--- a/selftest.sh
+++ b/selftest.sh
@@ -54,7 +54,7 @@ main() {
   fi
 
   # Start the runner
-  if ! cij_runner "$tplan_fpath" "$env_fpath" --output "$res_dpath" -vvv; then
+  if ! cij_runner --testplan "$tplan_fpath" --env "$env_fpath" --output "$res_dpath" -vvv; then
     cij::err "cij_runner encountered an error"
     res=$(( res + 1 ))
   fi

--- a/templates/report.html
+++ b/templates/report.html
@@ -97,43 +97,22 @@
 
       <ul class="nav nav-tabs card-header-tabs">
         <li class="nav-item">
-          <a class="nav-link active show" href="#SUMMARY" data-toggle="tab">Summary</a>
+          <a class="nav-link active show" href="#TRUN_SUMMARY" data-toggle="tab">Summary</a>
         </li>
         <li class="nav-item ml-auto">
-          <a class="nav-link" href="#RUNNER" data-toggle="tab">
+          <a class="nav-link" href="#TRUN_CONF" data-toggle="tab">
             Runner Conf ({{ dset.conf | length }})
           </a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#EVARS" data-toggle="tab">
-            Evars ({{ dset.evars | length }})
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#HOOKS" data-toggle="tab">
-            Hooks ({{ dset.hnames | length }})
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#AUX" data-toggle="tab">
-            Aux ({{ dset.aux_list | length }})
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#LOG" data-toggle="tab">
-            Log ({{ dset.log_content.splitlines() | length }})
-          </a>
-        </li>
       </ul>
-
     </div>
 
     <div class="tab-content">
 
-      <div class="tab-pane active" id="SUMMARY">
+      <div class="tab-pane active" id="TRUN_SUMMARY">
         <div class="card-body">
           <p class="card-text">
-          A total of <b>{{ tcases_count }}</b> testcases across <b>{{ dset.testsuites | length }}</b> testsuite(s).
+          A total of <b>{{ tcases_count }}</b> testcases across <b>{{ dset.testplans | length }}</b> testplans(s).
           </p>
           <p class="card-text">
           Test execution is {{ ((tcases_completed / tcases_count) * 100)|int }}% complete
@@ -171,7 +150,7 @@
         <div class="card-footer text-muted">&nbsp;</div>
       </div>
 
-      <div class="tab-pane" id="RUNNER">
+      <div class="tab-pane" id="TRUN_CONF">
 
         <div class="card-body">
           <h5 class="card-title">
@@ -199,73 +178,6 @@
         <div class="card-footer text-muted">&nbsp;</div>
       </div>
 
-      <!-- TRUN: EVARS-SNIPPET -->
-      <div class="tab-pane" id="EVARS">
-        <div class="card-body">
-          <p class="card-text">
-          A total of <b>{{ dset.evars | length }}</b> environment variables are defined.
-          Testsuites inherit testrun environment variables and testcases inherit testsuite
-          environment variables.
-          These environment variables and then defined before executing hooks and testcases, prior
-          to sourcing in the environment definition.
-          </p>
-        </div>
-
-        <ul class="list-group">
-        {% for evar in dset.evars %}
-        <li class="list-group-item">{{ evar }}: {{ dset.evars[evar] }}</li>
-        {% endfor %}
-        </ul>
-
-        <div class="card-footer text-muted">&nbsp;</div>
-      </div>
-
-      <!-- TRUN: HOOKS-SNIPPET -->
-      <div class="tab-pane" id="HOOKS">
-        <div class="card-body">
-          <p class="card-text">
-          A total of <b>{{ dset.hnames | length }}</b> hooks are used per testrun.
-          </p>
-        </div>
-
-        <ul class="list-group list-files">
-        {% for hname in dset.hnames %}
-        <li class="list-group-item">{{ hname }}</li>
-        {% endfor %}
-        </ul>
-
-        <div class="card-footer text-muted">&nbsp;</div>
-      </div>
-
-      <!-- TRUN: AUX-SNIPPET -->
-      <div class="tab-pane" id="AUX">
-        <div class="card-body">
-          <p class="card-text">
-          A total of <b>{{ dset.aux_list | length }}</b> auxilary files, produced by
-          testplan hooks, are listed below
-          </p>
-        </div>
-
-        <ul class="list-group list-files">
-        {% for aux in dset.aux_list %}
-        <li class="list-group-item"><a href="./{{ dset.aux_root[dset.conf.OUTPUT|length:] }}/{{ aux }}">{{ aux }}</a></li>
-        {% endfor %}
-        </ul>
-
-        <div class="card-footer text-muted">&nbsp;</div>
-      </div>
-
-      <!-- TRUN: LOG-SNIPPET -->
-      <div class="tab-pane runlog" id="LOG">
-        <div class="card-body">
-          <p class="card-text">
-          Output produced by executing testplan hooks is provided below
-          </p>
-        </div>
-        <pre><code class="runlog nohighlight">{{ dset.log_content | safe }}</code></pre>
-        <div class="card-footer text-muted">&nbsp;</div>
-      </div>
-
     </div>
   </div>
 </div>
@@ -276,8 +188,159 @@
   </div>
 </div>
 
+{% for tplan in dset.testplans %}
+
+<div class="jumbotron jumbotron-fluid">
+  <div class="container">
+    <h2 class="display-8">Testplan {{ tplan.name }} ( {{ tplan.ident }} )</h2>
+  </div>
+</div>
+
+<div class="container">
+  <div class="card mb-3">
+    <div class="card-header">
+      <ul class="nav nav-pills nav-fill card-header-pills no-gutters">
+        <li class="nav-item no-gutters">
+          <a class="nav-link bg-{{ trun_bg_color }} text-{{ trun_color }}">TESTPLAN <b>{{ tplan.status }}</b></a>
+        </li>
+      </ul>
+    </div>
+
+    <div class="card-header">
+      <ul class="nav nav-tabs card-header-tabs">
+        <li class="nav-item">
+          <a class="nav-link active show" href="#TPLAN_SUMMARY_{{ tplan.ident }}" data-toggle="tab">Summary</a>
+        </li>
+
+        <li class="nav-item ml-auto">
+          <a class="nav-link" href="#TPLAN_EVARS_{{ tplan.ident }}" data-toggle="tab">
+            Evars ({{ tplan.evars | length }})
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#TPLAN_HOOKS_{{ tplan.ident }}" data-toggle="tab">
+            Hooks ({{ tplan.hnames | length }})
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#TPLAN_AUX_{{ tplan.ident }}" data-toggle="tab">
+            Aux ({{ tplan.aux_list | length }})
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#TPLAN_LOG_{{ tplan.ident }}" data-toggle="tab">
+            Log ({{ tplan.log_content.splitlines() | length }})
+          </a>
+        </li>
+      </ul>
+    </div>
+
+    <div class="tab-content">
+      <div class="tab-pane active" id="TPLAN_SUMMARY_{{ tplan.ident }}">
+        <div class="card-body">
+          <p class="card-text">
+          Below is the progress for testcases within this testplan. See the tabs for environment
+          definitions, hooks, and output produced by running testplan-hooks.
+          </p>
+        </div>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Testcase Status</th>
+              <th>Count</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="table-success">
+              <td>PASS</td>
+              <td>{{ tplan.progress.PASS }}</td>
+            </tr>
+            <tr class="table-danger">
+              <td>FAIL</td>
+              <td>{{ tplan.progress.FAIL }}</td>
+            </tr>
+            <tr class="table-secondary">
+              <td>UNKN</td>
+              <td>{{ tplan.progress.UNKN }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="card-footer text-muted">&nbsp;</div>
+      </div>
+
+      <!-- TPLAN: EVARS-SNIPPET -->
+      <div class="tab-pane" id="TPLAN_EVARS_{{ tplan.ident }}">
+        <div class="card-body">
+          <p class="card-text">
+          A total of <b>{{ tplan.evars | length }}</b> environment variables are defined.
+          Testsuites inherit testrun environment variables and testcases inherit testsuite
+          environment variables.
+          These environment variables and then defined before executing hooks and testcases, prior
+          to sourcing in the environment definition.
+          </p>
+        </div>
+
+        <ul class="list-group">
+        {% for evar in tplan.evars %}
+        <li class="list-group-item">{{ evar }}: {{ tplan.evars[evar] }}</li>
+        {% endfor %}
+        </ul>
+
+        <div class="card-footer text-muted">&nbsp;</div>
+      </div>
+
+      <!-- TPLAN: HOOKS-SNIPPET -->
+      <div class="tab-pane" id="TPLAN_HOOKS_{{ tplan.ident }}">
+        <div class="card-body">
+          <p class="card-text">
+          A total of <b>{{ tplan.hnames | length }}</b> hooks are used per testrun.
+          </p>
+        </div>
+
+        <ul class="list-group list-files">
+        {% for hname in tplan.hnames %}
+        <li class="list-group-item">{{ hname }}</li>
+        {% endfor %}
+        </ul>
+
+        <div class="card-footer text-muted">&nbsp;</div>
+      </div>
+
+      <!-- TPLAN: AUX-SNIPPET -->
+      <div class="tab-pane" id="TPLAN_AUX_{{ tplan.ident }}">
+        <div class="card-body">
+          <p class="card-text">
+          A total of <b>{{ tplan.aux_list | length }}</b> auxilary files, produced by
+          testplan hooks, are listed below
+          </p>
+        </div>
+
+        <ul class="list-group list-files">
+        {% for aux in tplan.aux_list %}
+        <li class="list-group-item"><a href="./{{ tplan.aux_root[dset.conf.OUTPUT|length:] }}/{{ aux }}">{{ aux }}</a></li>
+        {% endfor %}
+        </ul>
+
+        <div class="card-footer text-muted">&nbsp;</div>
+      </div>
+
+      <!-- TPLAN: LOG-SNIPPET -->
+      <div class="tab-pane runlog" id="TPLAN_LOG_{{ tplan.ident }}">
+        <div class="card-body">
+          <p class="card-text">
+          Output produced by executing testplan hooks is provided below
+          </p>
+        </div>
+        <pre><code class="runlog nohighlight">{{ tplan.log_content | safe }}</code></pre>
+        <div class="card-footer text-muted">&nbsp;</div>
+      </div>
+
+    </div>
+  </div>  <!-- tplan-card -->
+</div><!-- tplan -->
+
 <div class="container" id="results">
-{% for tsuite in dset.testsuites %}
+{% for tsuite in tplan.testsuites %}
 
 {% set tsuite_bg_color = "secondary" %}
 {% set tsuite_bg_color = "success" if tsuite.status == "PASS" else tsuite_bg_color %}
@@ -525,6 +588,7 @@
 
 {% endfor %}
 </div>
+{% endfor %}
 <div class="jumbotron jumbotron-fluid">
   <div class="container">
     <h1 class="display-4">EOL</h1>


### PR DESCRIPTION
The basic functionality is in place; the runner can execute multiple testplans and visualize multiple plans in a single report. However, the following needs attention before merge:

* ~~The report-template, it is currently showing testplan info such as evars, hook-output etc. as part of the testrun, this should be moved down into the testplan-section.~~
* ~~The states of: status, progress, and wallc needs some verification, they are not accounted correctly.~~
  * ~~TestPlan now has "progress", however, it is not accounted correctly, this needs fixing.~~

Providing it now for early review and to determine possible collisions with the analyse feature.