### PR TITLE
Makeover plotlabels

### DIFF
--- a/bin/cij_plotter
+++ b/bin/cij_plotter
@@ -80,12 +80,12 @@ def metrics_to_pdata(args, metrics):
         pdata[ident]["yvals"].append(yval)
         pdata[ident]["xvals"].append(xval)
 
-    for lbl in pdata:
+    for ident in pdata:
         xvals, yvals = (list(t) for t in (
-            zip(*sorted(zip(pdata[lbl]["xvals"], pdata[lbl]["yvals"])))
+            zip(*sorted(zip(pdata[ident]["xvals"], pdata[ident]["yvals"])))
         ))
-        pdata[lbl]["xvals"] = xvals
-        pdata[lbl]["yvals"] = yvals
+        pdata[ident]["xvals"] = xvals
+        pdata[ident]["yvals"] = yvals
 
     return pdata
 

--- a/bin/cij_plotter
+++ b/bin/cij_plotter
@@ -10,6 +10,7 @@ import sys
 import os
 import matplotlib.ticker as mticker
 import matplotlib.pyplot as plt
+import jinja2
 import yaml
 import cij.analyser
 import cij.util
@@ -35,6 +36,17 @@ KEY_DESCR = {
     "bs": "Block-Size",
     "iodepth": "I/O-Depth"
 }
+
+
+def labelizer(ctx, fmt):
+    """Produces a label based on the given context, and format-string"""
+
+    tmpl = jinja2.Environment(
+        autoescape=True,
+        loader=jinja2.BaseLoader()
+    ).from_string(fmt)
+
+    return tmpl.render(**ctx)
 
 
 def collect_metrics(args):
@@ -75,7 +87,11 @@ def metrics_to_pdata(args, metrics):
         ).hexdigest()[:8]
 
         if ident not in pdata:
-            pdata[ident] = {"yvals": [], "xvals": [], "ctx": ctx}
+            pdata[ident] = {
+                "yvals": [], "xvals": [], "ctx": ctx, "label": ident
+            }
+            if args.label_fmt:  # overwrite default-label with user-template
+                pdata[ident]["label"] = labelizer(ctx, args.label_fmt)
 
         pdata[ident]["yvals"].append(yval)
         pdata[ident]["xvals"].append(xval)
@@ -93,11 +109,11 @@ def metrics_to_pdata(args, metrics):
 def plot_line(args, pdata):
     """Produce a line-plot of the given pdata"""
 
-    for marker, (ident, dset) in zip(MARKERS, pdata.items()):
+    for marker, (_, dset) in zip(MARKERS, pdata.items()):
         plt.plot(
             dset["xvals"],
             dset["yvals"],
-            label=ident,
+            label=dset["label"],
             marker=marker
         )
 
@@ -197,6 +213,11 @@ def parse_args():
         nargs="*",
         choices=["png", "pdf"],
         default=["png"]
+    )
+
+    prsr.add_argument(
+        "--label-fmt",
+        help="Provide a label format-string using jinja2 template syntax"
     )
 
     prsr.add_argument(


### PR DESCRIPTION
This provides a way for the user to format dataset-labels using dataset context.

```bash
cij_plotter \
	--output results/latest \
	--metric iops \
	--show 1 \
	--label-fmt="{{ioengine}}/{{bs}}"
```