### PR TITLE
Fixes

### DIFF
--- a/bin/cij_analyser
+++ b/bin/cij_analyser
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  CIJOE test analyser
 """

--- a/bin/cij_extractor
+++ b/bin/cij_extractor
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  CIJOE test extractor
 """

--- a/bin/cij_plotter
+++ b/bin/cij_plotter
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  CIJOE Metric Plotter
 """

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,4 @@
+pylint
+flake8
+mypy
+types-PyYAML


### PR DESCRIPTION
1. **explicitly use the Python 3 interpreter for all scripts**
Most scripts explicitly specify Python 3 (`#!/usr/bin/env python3`), but some did not - these other scripts would fail on systems where `#!/usr/bin/env python` still resolves to a Python 2 interpreter. 
This issue was observed on a machine with Ubuntu 20.10, upgraded from 20.04.

The behavior seems to stem from Debian 11 (bullseye) -- all Debian/Ubuntu packages now explicitly use `python2` or `python3` as their interpreter. ( source: https://packages.debian.org/sid/main/python-is-python2 )

Testing in a variety of recent Ubuntu releases (20.04, 20.10, 21.04), running `apt install python` causes the installation of `python-is-python2` which points `/usr/bin/python` to the python 2 interpreter.

Furthermore, [PEP 394](https://www.python.org/dev/peps/pep-0394/) makes explicit that installing a copy of python 3 _should_ make `python3` available on the path.

2. **provide `requirements.dev.txt` containing the development packages**
During `make selftest` some tests fail due to missing development packages. Installing the packages specified in this file will ensure all python-packages are available during self-test.
