### PR TITLE
Print the actual exception message wih FileExistsError is caught in c…

### DIFF
--- a/bin/cij_runner
+++ b/bin/cij_runner
@@ -136,3 +136,8 @@ if __name__ == "__main__":
         cij.warn(" 2) Remove the lock: '%s'" % FNAME)
         cij.warn(" 3) Start the runner")
         cij.err("---------============{[ UNCLEAN EXIT ]}===========---------")
+    except Exception as e:
+        cij.err("---------==========={[ CIJOE ERROR ]}==========---------")
+        cij.warn("There was an unhandled exception: ")
+        cij.warn(e)
+        cij.err("---------==========={[ CIJOE ERROR ]}==========---------")

--- a/bin/cij_runner
+++ b/bin/cij_runner
@@ -114,12 +114,13 @@ if __name__ == "__main__":
         os.remove(FNAME)
 
         sys.exit(RES)
-    except FileExistsError:
+    except FileExistsError as e:
         cij.err("---------==========={[ CIJOE IS LOCKED ]}==========---------")
         cij.warn("Looks like CIJOE is already running")
         cij.warn("or, a previous run did unclean exit")
         cij.warn("Clean up the target-system-under-test reboot / provision")
         cij.warn("Then remove '%s' and start the runner again" % FNAME)
+        cij.warn(e)
         cij.err("---------==========={[ CIJOE IS LOCKED ]}==========---------")
     except KeyboardInterrupt:
         cij.err("---------============{[ UNCLEAN EXIT ]}===========---------")

--- a/modules/cij/errors.py
+++ b/modules/cij/errors.py
@@ -20,3 +20,7 @@ class InvalidRangeError(CIJError):
 
 class UnknownUnitError(CIJError):
     """ Raised when attempting to use unknown units """
+
+
+class InvalidResultAuxPath(CIJError):
+    """ Raised when an invalid result is encountered with an auxuliary path """

--- a/modules/cij/runner.py
+++ b/modules/cij/runner.py
@@ -14,7 +14,7 @@ import os
 import yaml
 import cij.conf
 import cij
-from cij.errors import CIJError, InitializationError
+from cij.errors import CIJError, InitializationError, InvalidResultAuxPath
 # pylint:disable=unsubscriptable-object
 
 HOOK_PATTERNS = {
@@ -791,9 +791,9 @@ def trun_setup(args: argparse.Namespace, conf: cij.conf.Config) -> TestRun:
 
     try:
         os.makedirs(trun.aux_root)
-    except CIJError as ex:
-        cij.err("trun_setup: FAILED: makedirs. Error: %r" % ex)
-        raise Exception()
+    except FileExistsError as ex:
+        cij.err("trun_setup:FAILED os.makedirs(). %s" % ex)
+        raise InvalidResultAuxPath("failed makedir %s" % trun.aux_root) from ex
 
     trun.testplans = [
         tplan_setup(trun, tp_fpath) for tp_fpath in args.testplans
@@ -818,6 +818,7 @@ def main(args, conf):
         trun = trun_setup(args, conf)   # Construct 'trun' from args and conf
     except CIJError as ex:
         cij.err("main:FAILED to start testrun: %s" % ex)
+        return 1
 
     trun_to_file(trun)              # Persist trun
     trun_to_junitfile(trun)         # Persist as jUNIT XML

--- a/modules/cij/runner.py
+++ b/modules/cij/runner.py
@@ -789,7 +789,11 @@ def trun_setup(args: argparse.Namespace, conf: cij.conf.Config) -> TestRun:
     trun.res_root = args.output
     trun.aux_root = os.path.join(trun.res_root, "_aux")
 
-    os.makedirs(trun.aux_root)
+    try:
+        os.makedirs(trun.aux_root)
+    except CIJError as ex:
+        cij.err("trun_setup: FAILED: makedirs. Error: %r" % ex)
+        raise Exception()
 
     trun.testplans = [
         tplan_setup(trun, tp_fpath) for tp_fpath in args.testplans


### PR DESCRIPTION
At least another type of FileExistsError can occur when catching this exception.
* the makedirs in runner.py(792) can fail because that directory already exists.

But then the user incorrectly thinks its the lock file cannot fix the error. 
I fixed it by actually outputing the caught error.