### PR TITLE
cij: Add cij::cmd_output to be able to capture the output

### DIFF
--- a/modules/cij.sh
+++ b/modules/cij.sh
@@ -265,3 +265,8 @@ cij::cmd() {
     return 1
   fi
 }
+
+cij::cmd_output() {
+  SSH_CMD_QUIET=1 cij::cmd "$@"
+  return $?
+}


### PR DESCRIPTION
Just add a cmd that will not echo any additional output