### PR TITLE
Non-zero exit on error when failing to setup testrun

### DIFF
--- a/modules/cij/runner.py
+++ b/modules/cij/runner.py
@@ -814,6 +814,7 @@ def main(args, conf):
         trun = trun_setup(args, conf)   # Construct 'trun' from args and conf
     except CIJError as ex:
         cij.err("main:FAILED to start testrun: %s" % ex)
+        return 1
 
     trun_to_file(trun)              # Persist trun
     trun_to_junitfile(trun)         # Persist as jUNIT XML


### PR DESCRIPTION
An exception to setup `trun` causes another exception later when we attempt to use the variable and leaves a lock file.