### PR TITLE
setup: add cffi to the list of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "scp",
         "setuptools>=60",
         "watchdog",
+        "cffi",
     ],
     python_requires=">=3.9",
     entry_points={


### PR DESCRIPTION
Cijoe results in an error if cffi is not present. Add it to the list of deps while installing.

Error output:
    from . import _bcrypt
ModuleNotFoundError: No module named '_cffi_backend'