### PR TITLE
Add description option for a workflow run and a clean up to --archive option

### DIFF
--- a/src/cijoe/cli/cli.py
+++ b/src/cijoe/cli/cli.py
@@ -190,13 +190,7 @@ def cli_workflow(args):
         log.error("missing config")
         return errno.EINVAL
 
-    if args.output.exists():
-        archive = args.output.with_name("cijoe-archive") / str(
-            time.strftime("%Y-%m-%d_%H:%M:%S")
-        )
-        os.makedirs(archive)
-        log.info(f"moving existing output-directory to {archive}")
-        os.rename(args.output, archive)
+    cli_archive(args)
 
     state_path = args.output / "workflow.state"
     if state_path.exists():

--- a/src/cijoe/core/resources.py
+++ b/src/cijoe/core/resources.py
@@ -225,6 +225,7 @@ class Workflow(Resource):
     STATE_FILENAME = "workflow.state"
     STATE = {
         "doc": "",
+        "tag": "",
         "config": {},
         "steps": [],
         "status": {


### PR DESCRIPTION
It would be useful to give a tag for a workflow run
while running cijoe during development. This option enables
to give a tag that will be stored in the workflow.state. The same
text will be used as a prefix with timestamp while storing the results
in the archive folder.
    
Example usage:
```bash
$ cijoe -c default.config -w example.workflow -t "directIO" --tag "io_uring"
$ ls -la cijoe-archive/
directIO-io_uring-2023-02-07_06:44:34
```
