### PR TITLE
fix(transport): add support for env variables in csh, cmd and pwsh

### DIFF
--- a/src/cijoe/core/transport.py
+++ b/src/cijoe/core/transport.py
@@ -86,7 +86,7 @@ class SSH(Transport):
         """Initialize the CIJOE SSH Transport"""
 
         self.config = config
-        self.shell = self.config.options.get("run").get("shell", "sh")
+        self.shell = self.config.options.get("cijoe", {}).get("run", {}).get("shell", "sh")
         self.output_path = output_path
 
         self.ssh = paramiko.SSHClient()
@@ -124,6 +124,9 @@ class SSH(Transport):
 
     def run(self, cmd, cwd, env, logfile):
         """Invoke the given command"""
+
+        # Add environment variables defined in config.
+        env = self.config.options.get("cijoe", {}).get("run", {}).get("env", {}) | env
 
         # Seems like paramiko 'exec_command' or just SSH Accept-something... does not
         # like setting environment variables... thus.. this injection of them...


### PR DESCRIPTION
The commands for setting environment variables in csh (default on FreeBSD) and in cmd and PowerShell (Windows) are different than in sh.

Which shell is used, should be set in the config file. If none is set, sh is assumed.