### PR TITLE
refactor(config): move transport item to cijoe

### DIFF
--- a/docs/source/resources/configs/index.rst
+++ b/docs/source/resources/configs/index.rst
@@ -5,7 +5,7 @@ Configs
 
 **cijoe** configuration files are formated using `YAML`_ and named with suffix
 ``.config``. In the core functionality of provided by cijoe, only the key
-``transport`` has special meaning.
+``cijoe.transport`` has special meaning.
 
 Keys are otherwise granted meaning by their use of
 :ref:`sec-resources-scripts`, tests, and regular Python modules.

--- a/src/cijoe/core/command.py
+++ b/src/cijoe/core/command.py
@@ -75,7 +75,7 @@ class Cijoe(object):
         self.transport_local = transport.Local(self.config, self.output_path)
         self.transport = self.transport_local
 
-        ssh = self.config.options.get("transport", {}).get("ssh", None)
+        ssh = self.config.options.get("cijoe", {}).get("transport", {}).get("ssh", None)
         if ssh:
             self.transport = transport.SSH(self.config, self.output_path)
 

--- a/src/cijoe/core/configs/transport-ssh.toml
+++ b/src/cijoe/core/configs/transport-ssh.toml
@@ -1,5 +1,5 @@
 # The SSH options are passed verbatim to paramiko; see https://www.paramiko.org/
-[transport.ssh]
+[cijoe.transport.ssh]
 username = "root"
 hostname = "test_target"
 port = 22

--- a/src/cijoe/core/scripts/testrunner.py
+++ b/src/cijoe/core/scripts/testrunner.py
@@ -104,8 +104,8 @@ def pytest_remote(args, cijoe, step):
     config_path_local = args.output / cijoe.output_ident / config_stem
 
     config = copy.deepcopy(cijoe.config.options)
-    if "transport" in config and "ssh" in config["transport"]:
-        del config["transport"]["ssh"]
+    if "transport" in config.get("cijoe", {}) and "ssh" in config["cijoe"]["transport"]:
+        del config["cijoe"]["transport"]["ssh"]
 
     dict_to_tomlfile(config, config_path_local)
     cijoe.put(str(config_path_local), config_path)

--- a/src/cijoe/core/transport.py
+++ b/src/cijoe/core/transport.py
@@ -115,7 +115,7 @@ class SSH(Transport):
         )
 
     def __connect(self):
-        self.ssh.connect(**self.config.options.get("transport").get("ssh"))
+        self.ssh.connect(**self.config.options.get("cijoe", {}).get("transport").get("ssh"))
         self.scp = SCPClient(self.ssh.get_transport())
 
     def __disconnect(self):

--- a/src/cijoe/fio/selftest/test_fio_wrapper.py
+++ b/src/cijoe/fio/selftest/test_fio_wrapper.py
@@ -7,7 +7,7 @@ import cijoe.fio.wrapper as fio
 def skip_when_config_has_no_remote(cijoe):
     """Skip testing when configuration is module not enabled"""
 
-    transport = cijoe.config.options.get("transport", None)
+    transport = cijoe.config.options.get("cijoe", {}).get("transport", None)
     if not transport:
         pytest.skip(reason="skipping as there is no remote transport defined")
 

--- a/src/cijoe/linux/scripts/transfer_and_install_kdebs.py
+++ b/src/cijoe/linux/scripts/transfer_and_install_kdebs.py
@@ -11,7 +11,7 @@ Transfer and install Linux Kernel .deb
 Retargetable: True
 ------------------
 
-Transfer from local to remote, the config.transport.ssh determines the remote.
+Transfer from local to remote, the config.cijoe.transport.ssh determines the remote.
 """
 import errno
 import logging as log

--- a/src/cijoe/linux/selftest/test_null_blk.py
+++ b/src/cijoe/linux/selftest/test_null_blk.py
@@ -6,7 +6,7 @@ import cijoe.linux.null_blk as null_blk
 def skip_when_config_has_no_remote(cijoe):
     """Skip testing when configuration is module not enabled"""
 
-    transport = cijoe.config.options.get("transport", None)
+    transport = cijoe.config.options.get("cijoe", {}).get("transport", None)
     if not transport:
         pytest.skip(reason="skipping as there is no remote transport defined")
 

--- a/src/cijoe/qemu/configs/debian-bookworm-amd64-kvm.toml
+++ b/src/cijoe/qemu/configs/debian-bookworm-amd64-kvm.toml
@@ -2,7 +2,7 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
-[transport.ssh]
+[cijoe.transport.ssh]
 username = "root"
 password = "root"
 hostname = "localhost"

--- a/src/cijoe/qemu/configs/debian-bookworm-arm64-hvf.toml
+++ b/src/cijoe/qemu/configs/debian-bookworm-arm64-hvf.toml
@@ -2,7 +2,7 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
-[transport.ssh]
+[cijoe.transport.ssh]
 username = "root"
 password = "root"
 hostname = "localhost"

--- a/src/cijoe/qemu/configs/debian-bullseye-amd64-kvm.toml
+++ b/src/cijoe/qemu/configs/debian-bullseye-amd64-kvm.toml
@@ -2,7 +2,7 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
-[transport.ssh]
+[cijoe.transport.ssh]
 username = "root"
 password = "root"
 hostname = "localhost"

--- a/src/cijoe/qemu/configs/default-config.toml
+++ b/src/cijoe/qemu/configs/default-config.toml
@@ -2,7 +2,7 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
-[transport.ssh]
+[cijoe.transport.ssh]
 username = "root"
 password = "root"
 hostname = "localhost"

--- a/src/cijoe/qemu/configs/freebsd-13-amd64-kvm.toml
+++ b/src/cijoe/qemu/configs/freebsd-13-amd64-kvm.toml
@@ -2,7 +2,7 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
-[transport.ssh]
+[cijoe.transport.ssh]
 username = "root"
 password = ""
 hostname = "localhost"


### PR DESCRIPTION
Move the top-level item `transport` under top-level item `cijoe` to match with all other top level identifiers in the configuration-file.

Closes #60 