### PR TITLE
fix(resources): remove unused setuptools import

### DIFF
--- a/src/cijoe/core/resources.py
+++ b/src/cijoe/core/resources.py
@@ -51,7 +51,6 @@ except ImportError:
     from importlib_resources import files as importlib_files
 
 import jinja2
-import setuptools  # noqa
 import yaml
 
 import cijoe


### PR DESCRIPTION
This import is unused in the code - but it makes installing cijoe on MacOS more painful than it should be.