### PR TITLE
feat(workflows): add support for constants

### DIFF
--- a/src/cijoe/core/resources.py
+++ b/src/cijoe/core/resources.py
@@ -322,7 +322,7 @@ class Workflow(Resource):
 
         errors = []
 
-        for top in set(topic.keys()) - set(["doc", "config", "steps"]):
+        for top in set(topic.keys()) - set(["doc", "config", "steps", "constants"]):
             errors.append(f"Unsupported top-level key: '{top}'")
             return errors
         for top in ["doc", "steps"]:

--- a/src/cijoe/core/workflows/example-workflow.yaml
+++ b/src/cijoe/core/workflows/example-workflow.yaml
@@ -18,6 +18,11 @@ doc: |
   The commands and the scripts are passed an instance of cijoe which they can use to call
   run()/get()/put(), with an output-directory matching the current step. This is it, end of story.
 
+constants:
+- values: &a
+  - value1
+  - value2
+
 steps:
 - name: info
   run: |
@@ -28,3 +33,4 @@ steps:
   uses: core.testrunner
   with:
     args: "--pyargs cijoe.core.selftest"
+    values: *a


### PR DESCRIPTION
To be able to reuse constants throughout the workflow file, let the workflow file have a top-level key called "constants" where a constant can be defined with the &-notation and referenced with an asterisk (*).