### PR TITLE
Stand-alone execution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ package_dir =
 where = src
 
 [options.package_data]
-* = *.html, *.config, *.perfreq, *.toml, *.yaml, *.workflow, *.user, *.meta
+* = *.html, *.config, *.perfreq, *.toml, *.yaml, *.workflow, *.user, *.meta, *.jinja2
 [options.entry_points]
 console_scripts =
   cijoe = cijoe.cli.cli:main

--- a/src/cijoe/core/resources.py
+++ b/src/cijoe/core/resources.py
@@ -308,6 +308,10 @@ class Workflow(Resource):
             return errors
 
         for step in topic["steps"]:
+            if step["name"].endswith(".py"):
+                errors.append("Illegal step name: Suffix .py reserved for Python scripts")
+                return errors
+            
             if "run" not in step.keys():
                 continue
 

--- a/src/cijoe/core/selftest/test_collector.py
+++ b/src/cijoe/core/selftest/test_collector.py
@@ -5,7 +5,7 @@ from cijoe.core.resources import Collector
 
 CORE_RESOURCE_COUNTS = {
     "configs": 2,
-    "templates": 1,
+    "templates": 2,
     "auxiliary": 1,
     "scripts": 7,
 }

--- a/src/cijoe/core/templates/example-tmp-workflow.yaml.jinja2
+++ b/src/cijoe/core/templates/example-tmp-workflow.yaml.jinja2
@@ -1,0 +1,9 @@
+---
+doc: |
+  Temporary standalone script
+
+steps:
+{% for path in paths %}
+- name: {{path.stem}}
+  uses: {{path.stem}}
+{% endfor %}


### PR DESCRIPTION
Allows cijoe-scripts to be run with cijoe, so for example `cijoe cijoe-script.py`. The `.py` suffix is reserved for python scripts, and cannot be used in workflow step names. 

Multiple cijoe-scripts can be executed in sequence as a workflow, for example `cijoe script1.py script2.py`, but requires that all arguments ends with `.py`. If one or more arguments does not end with `.py`, the arguments are treated as workflow steps.