### PR TITLE
fix(cli): add standalone script paths to search paths for auto-discovery 

### DIFF
--- a/src/cijoe/cli/cli.py
+++ b/src/cijoe/cli/cli.py
@@ -364,8 +364,12 @@ def cli_workflow(args):
 
 
 def create_adhoc_workflow(args, paths):
-    resources = get_resources()
-    paths = map(Path, paths)
+    paths = list(map(Path, paths))
+    if len(set(path.stem for path in paths)) != len(paths):
+        log.error("Duplicate script file names not allowed.")
+        sys.exit(1)
+
+    resources = get_resources([step.parent for step in paths])
 
     template_path = resources["templates"]["core.example-tmp-workflow.yaml"].path
     jinja_env = jinja2.Environment(

--- a/src/cijoe/core/resources.py
+++ b/src/cijoe/core/resources.py
@@ -440,11 +440,8 @@ class Collector(object):
     def __new__(cls):
         if not hasattr(cls, "instance"):
             cls.instance = super(Collector, cls).__new__(cls)
+            cls.instance.reset()
         return cls.instance
-
-    def __init__(self):
-        self.resources = {category: {} for category, _ in Collector.RESOURCES}
-        self.is_done = False
 
     def __process_candidate(self, candidate: Path, category: str, pkg):
         """Inserts the given candidate"""
@@ -463,6 +460,10 @@ class Collector(object):
             resource = Resource(candidate, pkg)
 
         self.resources[category][resource.ident] = resource
+
+    def reset(self):
+        self.resources = {category: {} for category, _ in Collector.RESOURCES}
+        self.is_done = False
 
     def collect_from_path(self, path=None, max_depth=2):
         """Collects non-packaged scripts from the given 'path'"""

--- a/src/cijoe/core/resources.py
+++ b/src/cijoe/core/resources.py
@@ -511,7 +511,7 @@ class Collector(object):
 
                 self.__process_candidate(candidate, category, pkg)
 
-    def collect(self):
+    def collect(self, paths=[]):
         """Collect from all implemented resource "sources" """
 
         if self.is_done:
@@ -519,6 +519,9 @@ class Collector(object):
 
         self.collect_from_packages(cijoe.__path__, "cijoe.")
         self.collect_from_path()
+
+        for path in paths:
+            self.collect_from_path(path, 0)
 
         cwd = Path().cwd() / ".cijoe"
         if cwd.exists():
@@ -531,10 +534,10 @@ class Collector(object):
         self.is_done = True
 
 
-def get_resources():
+def get_resources(paths=[]):
     """Returns resources collected by Collector"""
 
     collector = Collector()
-    collector.collect()
+    collector.collect(paths)
 
     return collector.resources

--- a/src/cijoe/core/selftest/conftest.py
+++ b/src/cijoe/core/selftest/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from cijoe.core.resources import Collector
 
 
 @pytest.fixture
@@ -19,3 +20,10 @@ def xnvme(cijoe, capsys):
 
     for device in nvme.get("devices", []):
         return device
+
+
+@pytest.fixture(autouse=True)
+def reset_collector():
+    # This fixture runs automatically before each test
+    collector = Collector()
+    collector.reset()


### PR DESCRIPTION
When running cijoe-scripts with the `cijoe` cli, they might be out of reach for the cijoe auto-discovery. In order to allow execution of the scripts, add parent paths to collected paths.

Solves point 4 under "Nice to have" in https://github.com/refenv/cijoe/issues/73