### PR TITLE
bugfix(transport): combine stdout and stderr instead of using get_pty

### DIFF
--- a/src/cijoe/core/transport.py
+++ b/src/cijoe/core/transport.py
@@ -163,7 +163,8 @@ class SSH(Transport):
         try:
             self.__connect()
 
-            _, stdout, _ = self.ssh.exec_command(cmd, environment=env, get_pty=True)
+            _, stdout, _ = self.ssh.exec_command(cmd, environment=env)
+            stdout.channel.set_combine_stderr(True)
 
             while not stdout.channel.exit_status_ready():
                 cmd_output.write(stdout.read(1))


### PR DESCRIPTION
`get_pty=True` must have some other side-effects than anticipated, as if `cmd` is set to for example `powershell "echo hi"`, then `stdout.channel.exit_status_ready()` will never return True. The parameter is not necessary for streaming output in real-time though, so we combine `stdout` and `stderr` with the `set_combine_stderr(True)` instead.