### PR TITLE
fix(cli): drop support for running scripts with python interpreter

### DIFF
--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -34,7 +34,7 @@ The command-line tool is aptly named ``cijoe``.
 To create a **cijoe** Python script, run command ``cijoe --script``, which
 will create a python script with the code necessary for running **cijoe**.
 
-The script is executed by running ``python ./cijoe-script.py --config
+The script is executed by running ``cijoe ./cijoe-script.py --config
 path/to/config.toml``.
 
 .. literalinclude:: ../../../src/cijoe/core/scripts/example.py

--- a/src/cijoe/cli/cli.py
+++ b/src/cijoe/cli/cli.py
@@ -376,12 +376,6 @@ def create_adhoc_workflow(args, paths):
         sys.exit(main(args))
 
 
-def cli_interface(path):
-    path = Path(path)
-    args = parse_args()
-    create_adhoc_workflow(args, [path])
-
-
 def parse_args():
     """Parse command-line interface."""
 

--- a/src/cijoe/core/scripts/example.py
+++ b/src/cijoe/core/scripts/example.py
@@ -1,6 +1,5 @@
 from argparse import Namespace
 
-from cijoe.cli.cli import cli_interface
 from cijoe.core.command import Cijoe
 
 
@@ -9,7 +8,3 @@ def main(args: Namespace, cijoe: Cijoe, step: dict):
     if "Hello" not in state.output():
         return 1
     return err
-
-
-if __name__ == "__main__":
-    cli_interface(__file__)


### PR DESCRIPTION
Now that standalone cijoe scripts can be run with
`cijoe path/to/cijoe-script.py`, we drop support for running standalone cijoe scripts with the python intepreter. This way we only have one entrypoint of running cijoe-scripts, which ultimately makes both the cijoe scripts and cijoe as a tool simpler.

Solves the comment from Oct 16 2024 on issue #73