### PR TITLE
feat(transport): allow defining multiple transport endpoints

### DIFF
--- a/docs/source/resources/configs/index.rst
+++ b/docs/source/resources/configs/index.rst
@@ -76,6 +76,38 @@ password login or key-based login. You can configure it as follows:
    key_filename = "path/to/private_key"
    passphrase   = "baz"
 
+
+Configuring multiple transports
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When executing scripts over an **ssh** connection, **cijoe** connects to the
+first transport defined under the ``cijoe.transport`` key. If you need to 
+connect to multiple different transports, you can define them under different
+keys, for example:
+
+.. code-block:: toml
+   
+   [cijoe.transport.machineA]
+   hostname = "machineA"
+   port = 22
+   username = "foo"
+   password = "bar"
+
+   [cijoe.transport.machineB]
+   hostname = "machineB"
+   port = 22
+   username = "foo"
+   key_filename = "path/to/private_key"
+
+To execute commands on a specific transport, use the ``transport_name`` 
+parameter of ``cijoe.run(...)``, for example:
+
+.. code-block:: python
+
+   cijoe.run("hostname")                             # will run on machineA
+   cijoe.run("hostname", transport_name="machineB")  # will run on machineB
+
+
 Shell Configuration
 -------------------
 

--- a/src/cijoe/core/transport.py
+++ b/src/cijoe/core/transport.py
@@ -87,7 +87,7 @@ class Local(Transport):
 class SSH(Transport):
     """Provide cmd/push/pull over SSH"""
 
-    def __init__(self, config, output_path):
+    def __init__(self, config, output_path, transport_name):
         """Initialize the CIJOE SSH Transport"""
 
         self.config = config
@@ -97,6 +97,9 @@ class SSH(Transport):
         self.output_path = output_path
 
         self.ssh = paramiko.SSHClient()
+        self.ssh_params = (
+            self.config.options.get("cijoe", {}).get("transport").get(transport_name)
+        )
 
         # Using the 'AutoAddPolicy()' *without* load_system_host_keys(), by doing so,
         # then Paramiko does not know any hosts, and simply adds them first time they
@@ -122,9 +125,7 @@ class SSH(Transport):
         )
 
     def __connect(self):
-        self.ssh.connect(
-            **self.config.options.get("cijoe", {}).get("transport").get("ssh")
-        )
+        self.ssh.connect(**self.ssh_params)
         self.scp = SCPClient(self.ssh.get_transport())
 
     def __disconnect(self):

--- a/src/cijoe/linux/scripts/transfer_and_install_kdebs.py
+++ b/src/cijoe/linux/scripts/transfer_and_install_kdebs.py
@@ -11,7 +11,7 @@ Transfer and install Linux Kernel .deb
 Retargetable: True
 ------------------
 
-Transfer from local to remote, the config.cijoe.transport.ssh determines the remote.
+Transfer from local to remote, the config.cijoe.transport determines the remote.
 """
 
 import errno

--- a/src/cijoe/qemu/configs/debian-bookworm-amd64-kvm.toml
+++ b/src/cijoe/qemu/configs/debian-bookworm-amd64-kvm.toml
@@ -2,7 +2,7 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
-[cijoe.transport.ssh]
+[cijoe.transport.qemu_guest]
 username = "root"
 password = "root"
 hostname = "localhost"

--- a/src/cijoe/qemu/configs/debian-bookworm-arm64-hvf.toml
+++ b/src/cijoe/qemu/configs/debian-bookworm-arm64-hvf.toml
@@ -2,7 +2,7 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
-[cijoe.transport.ssh]
+[cijoe.transport.qemu_guest]
 username = "root"
 password = "root"
 hostname = "localhost"

--- a/src/cijoe/qemu/configs/debian-bullseye-amd64-kvm.toml
+++ b/src/cijoe/qemu/configs/debian-bullseye-amd64-kvm.toml
@@ -2,7 +2,7 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
-[cijoe.transport.ssh]
+[cijoe.transport.qemu_guest]
 username = "root"
 password = "root"
 hostname = "localhost"

--- a/src/cijoe/qemu/configs/default-config.toml
+++ b/src/cijoe/qemu/configs/default-config.toml
@@ -2,7 +2,7 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
-[cijoe.transport.ssh]
+[cijoe.transport.qemu_guest]
 username = "root"
 password = "root"
 hostname = "localhost"

--- a/src/cijoe/qemu/configs/freebsd-13-amd64-kvm.toml
+++ b/src/cijoe/qemu/configs/freebsd-13-amd64-kvm.toml
@@ -2,7 +2,7 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
-[cijoe.transport.ssh]
+[cijoe.transport.qemu_guest]
 username = "root"
 password = ""
 hostname = "localhost"


### PR DESCRIPTION
Added the `endpoint_name` parameter to `cijoe.run(...)`, which allows users to specify which endpoint they want to execute commands on. Endpoints are defined in the configuration file under the key `cijoe.transport` with user-defined names. If the `endpoint_name` parameter is not given, the command is executed on the first defined endpoint. If no endpoints are defined, the command is executed on the initiator.

Solves issue #75