### PR TITLE
Add the creation of a Docker image that can be used by cijoe itself.

### DIFF
--- a/.github/cijoe-docker/Dockerfile
+++ b/.github/cijoe-docker/Dockerfile
@@ -1,0 +1,59 @@
+FROM debian:bookworm
+
+WORKDIR /opt
+
+RUN apt-get -qy update && \
+	apt-get -qy \
+		-o "Dpkg::Options::=--force-confdef" \
+		-o "Dpkg::Options::=--force-confold" upgrade && \
+	apt-get -qy autoclean
+
+RUN apt-get -qy -f install \
+	bridge-utils \
+	build-essential \
+	cloud-image-utils \
+	genisoimage \
+	git \
+	guestmount \
+	htop \
+	lshw \
+	neovim \
+	openssh-server \
+	pipx \
+	procps \
+	python3-build \
+	python3-jinja2 \
+	qemu-kvm \
+	qemu-system-arm \
+	qemu-system-x86 \
+	qemu-utils \
+	ssh \
+	time
+
+RUN pipx ensurepath
+
+# Setup SSH
+RUN echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+RUN systemctl enable ssh
+RUN service ssh restart
+RUN mkdir -p /root/.ssh
+RUN chmod 0700 /root/.ssh
+RUN ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N ""
+RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+
+# Don't want any of that hastle
+RUN echo "Host *" >> /root/.ssh/config
+RUN echo "  StrictHostKeyChecking no" >> /root/.ssh/config
+RUN echo "  NoHostAuthenticationForLocalhost yes" >> /root/.ssh/config
+RUN echo "  UserKnownHostsFile=/dev/null" >> /root/.ssh/config
+RUN chmod 0400 /root/.ssh/config
+
+# This does not apply when SSH-ing to localhost, then ENV set by this is cleared
+ENV PATH="/opt/qemu/bin:$PATH"
+# So we also add it to /root/.profile
+RUN echo 'PATH="/opt/qemu/bin:$PATH"' > /root/.profile
+
+# Check that the correct qemu is being called
+RUN qemu-system-x86_64 --version
+
+CMD ["bash"]

--- a/.github/workflows/cijoe_docker.yml
+++ b/.github/workflows/cijoe_docker.yml
@@ -1,0 +1,50 @@
+---
+#
+# Build a Docker image with qemu which can be utilized to run qemu guests via
+# containers on GitHUB, the image has the following systems:
+#
+# * qemu-system-aarch64
+# * qemu-system-arm
+# * qemu-system-i386
+# * qemu-system-x86_64
+# * qemu-system-x86_64-microvm
+#
+name: cijoe_docker
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - cijoe_docker
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  build_and_push:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4.2.2
+
+    - name: Build Docker image
+      run: |
+        IMAGE_ID=ghcr.io/${{ github.repository_owner }}/cijoe-docker
+        docker build \
+          -t ${IMAGE_ID}:${DOCKER_TAG} \
+          -f .github/cijoe-docker/Dockerfile \
+          .
+
+    - name: Authenticate to GitHub Container Registry
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Push Docker image to registry
+      run: |
+        IMAGE_ID=ghcr.io/${{ github.repository_owner }}/cijoe-docker
+        docker push ${IMAGE_ID}:${DOCKER_TAG}

--- a/src/cijoe/core/selftest/test_workflow.py
+++ b/src/cijoe/core/selftest/test_workflow.py
@@ -39,21 +39,21 @@ def test_workflow_lint_valid_workflow(tmp_path):
 
     data = copy.deepcopy(WORKFLOW_SKELETON)
 
-    with (tmp_path / "workflow.yaml").resolve() as workflow_file:
-        workflow_file.write_text(yaml.dump(data))
+    workflow_file = (tmp_path / "workflow.yaml").resolve()
+    workflow_file.write_text(yaml.dump(data))
 
-        result = subprocess.run(
-            [
-                "cijoe",
-                "--integrity-check",
-                "--workflow",
-                str(workflow_file),
-                "--config",
-                str(config_path),
-            ],
-            cwd=str(tmp_path),
-        )
-        assert result.returncode == 0
+    result = subprocess.run(
+        [
+            "cijoe",
+            "--integrity-check",
+            "--workflow",
+            str(workflow_file),
+            "--config",
+            str(config_path),
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0
 
 
 def test_workflow_lint_invalid_step_name(tmp_path):
@@ -64,21 +64,21 @@ def test_workflow_lint_invalid_step_name(tmp_path):
     data = copy.deepcopy(WORKFLOW_SKELETON)
     data.get("steps", []).append({"name": "cannot have spaces", "with": "core.example"})
 
-    with (tmp_path / "workflow.yaml").resolve() as workflow_file:
-        workflow_file.write_text(yaml.dump(data))
+    workflow_file = (tmp_path / "workflow.yaml").resolve()
+    workflow_file.write_text(yaml.dump(data))
 
-        result = subprocess.run(
-            [
-                "cijoe",
-                "--integrity-check",
-                "--workflow",
-                str(workflow_file),
-                "--config",
-                str(config_path),
-            ],
-            cwd=str(tmp_path),
-        )
-        assert result.returncode != 0
+    result = subprocess.run(
+        [
+            "cijoe",
+            "--integrity-check",
+            "--workflow",
+            str(workflow_file),
+            "--config",
+            str(config_path),
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode != 0
 
 
 def test_workflow_report_command_ordering(tmp_path):
@@ -92,22 +92,22 @@ def test_workflow_report_command_ordering(tmp_path):
     )
 
     output_path = (tmp_path / "output").resolve()
-    with (tmp_path / "workflow.yaml").resolve() as workflow_file:
-        workflow_file.write_text(yaml.dump(data))
+    workflow_file = (tmp_path / "workflow.yaml").resolve()
+    workflow_file.write_text(yaml.dump(data))
 
-        result = subprocess.run(
-            [
-                "cijoe",
-                "--output",
-                str(output_path),
-                "--workflow",
-                str(workflow_file),
-                "--config",
-                str(config_path),
-            ],
-            cwd=str(tmp_path),
-        )
-        assert result.returncode == 0
+    result = subprocess.run(
+        [
+            "cijoe",
+            "--output",
+            str(output_path),
+            "--workflow",
+            str(workflow_file),
+            "--config",
+            str(config_path),
+        ],
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0
 
     for count, key in enumerate(
         runlog_from_path(output_path / "002_many_commands").keys(), 1


### PR DESCRIPTION
To test the cijoe QEMU package and the system-imaging packages, they should be verified using GitHub workflows. This preparation involves providing a Docker image with QEMU installed, which can be used in a GitHub workflow.

There is also a fix in here as I stumbled upon it.