### PR TITLE
Add a 'cijoe-docker' image containing everything needed for cijoe and packages

### DIFF
--- a/.github/cijoe-docker/Dockerfile
+++ b/.github/cijoe-docker/Dockerfile
@@ -1,0 +1,99 @@
+# Introduction
+# ============
+#
+# This Dockerfile sets up an environment to run cijoe in CI pipelines, 
+# such as those provided by GitHub Actions. It supports:
+#
+# * Building, installing, and running cijoe.
+# * Running QEMU-guest in Docker:
+#   - Ideal for using custom virtual machines on GitHub Actions.
+# * Running Docker-in-Docker (DinD):
+#   - Useful for executing 'docker build' within a Docker container.
+#
+# Based on Debian, this image leverages one of the most renowned Linux distributions, 
+# offering a familiar environment for Ubuntu users. Debian provides freedom, 
+# stability, and a vast selection of up-to-date packages.
+#
+# Custom QEMU
+# ===========
+#
+# For specific use cases, you might require a more recent version of QEMU. 
+# In such cases, this image can serve as a base, allowing you to extend it 
+# by building a custom version of QEMU. This approach can provide newer 
+# features or enable functionality not available in upstream versions.
+FROM debian:bookworm
+
+WORKDIR /opt
+
+RUN apt-get -qy update && \
+	apt-get -qy \
+	-o "Dpkg::Options::=--force-confdef" \
+	-o "Dpkg::Options::=--force-confold" upgrade \
+	&& \
+	apt-get -qy autoclean
+
+RUN apt-get -qy -f install --no-install-recommends \
+	bridge-utils \
+	build-essential \
+	ca-certificates \
+	cloud-image-utils \
+	docker.io \
+	fuse3 \
+	genisoimage \
+	git \
+	guestmount \
+	htop \
+	libguestfs-tools \
+	linux-image-amd64 \
+	lshw \
+	neovim \
+	openssh-server \
+	pipx \
+	procps \
+	python3-build \
+	python3-jinja2 \
+	qemu-kvm \
+	qemu-system-arm \
+	qemu-system-x86 \
+	qemu-utils \
+	ssh \
+	time \
+	&& \
+	apt-get -qy clean && \
+	apt-get -qy autoremove && \
+	rm -rf /var/lib/apt/lists/* \
+	pipx ensurepath
+
+# Proide the cijoe-version as argument to the build and expose it in ENV
+ARG CIJOE_VERSION
+ENV CIJOE_VERSION=$CIJOE_VERSION
+
+# Setup environment variables for pipx
+ENV PIPX_HOME=/root/.local/pipx
+ENV PATH=/root/.local/bin::$PATH
+
+# Install cijoe itself
+RUN pipx install cijoe==$CIJOE_VERSION
+
+#
+# Modified SSH Configuration, this is done enable the use of ssh to localhost
+# without being prompted
+#
+
+# Setup SSH
+RUN echo "PermitRootLogin yes" >> /etc/ssh/sshd_config && \
+	systemctl enable ssh && \
+	service ssh restart && \
+	mkdir -p /root/.ssh && \
+	chmod 0700 /root/.ssh && \
+	ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N "" && \
+	cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+
+# Don't want any of that hastle
+RUN echo "Host *" >> /root/.ssh/config && \
+	echo "  StrictHostKeyChecking no" >> /root/.ssh/config && \
+	echo "  NoHostAuthenticationForLocalhost yes" >> /root/.ssh/config && \
+	echo "  UserKnownHostsFile=/dev/null" >> /root/.ssh/config && \
+	chmod 0400 /root/.ssh/config
+
+CMD ["bash"]

--- a/.github/workflows/cijoe_docker.yml
+++ b/.github/workflows/cijoe_docker.yml
@@ -1,0 +1,48 @@
+---
+# Build and deploy a Docker image for cijoe with access to Docker and QEMU.
+#
+# The image is built and pushed to GitHub Container Registry (GHCR) when:
+# 1. Triggered manually via workflow_dispatch.
+# 2. Changes are pushed to 'cijoe_docker' branch
+#
+# Refer to `.github/workflows/cijoe_docker.yml` for details on this workflow.
+name: cijoe_docker
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - 'cijoe_docker'
+
+env:
+  DOCKER_IMAGE: ghcr.io/${{ github.repository_owner }}/cijoe-docker
+  DOCKER_TAG: v0.9.45
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4.2.2
+
+    - name: Authenticate to GitHub Container Registry
+      uses: docker/login-action@v3.3.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build Docker image
+      run: |
+        docker buildx build \
+          --build-arg CIJOE_VERSION=${{ env.DOCKER_TAG }} \
+          --tag ${{ env.DOCKER_IMAGE }}:latest \
+          --tag ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }} \
+          --file .github/cijoe-docker/Dockerfile \
+          .
+
+    - name: Push Docker image to registry
+      run: |
+        docker push ${{ env.DOCKER_IMAGE }}:latest
+        docker push ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}


### PR DESCRIPTION
To test the cijoe QEMU package and the system-imaging packages, they should be verified using GitHub workflows. This preparation involves providing a Docker image with QEMU installed, which can be used in a GitHub workflow.

There is also a fix in here as I stumbled upon it.