### PR TITLE
feat(ci): add 'meson' to 'cijoe-docker'

### DIFF
--- a/.github/cijoe-docker/Dockerfile
+++ b/.github/cijoe-docker/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get -qy -f install --no-install-recommends \
 	libguestfs-tools \
 	linux-image-amd64 \
 	lshw \
+	meson \
 	neovim \
 	openssh-server \
 	pipx \


### PR DESCRIPTION
meson is needed to build qemu from source, which is one of the built-in scripts and examples of the 'qemu' package.