### PR TITLE
feat(ci): add 'glib2' to 'cijoe-docker'

### DIFF
--- a/.github/cijoe-docker/Dockerfile
+++ b/.github/cijoe-docker/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get -qy -f install --no-install-recommends \
 	git \
 	guestmount \
 	htop \
+	libglib2.0-dev \
 	libguestfs-tools \
 	linux-image-amd64 \
 	lshw \


### PR DESCRIPTION
glib2 is needed to build qemu from source, which is one of the built-in scripts and examples of the 'qemu' package.