### PR TITLE
feat(gha): add verification of the cijoe package, fio

### DIFF
--- a/.github/workflows/cijoe_packages.yml
+++ b/.github/workflows/cijoe_packages.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        usage_example: ['system_imaging', 'qemu.build']
+        usage_example: ['fio', 'system_imaging', 'qemu.build']
         python-version: ['3.12']
 
     steps:

--- a/src/cijoe/fio/configs/example_config_benchmark.toml
+++ b/src/cijoe/fio/configs/example_config_benchmark.toml
@@ -1,0 +1,24 @@
+# Declaration of where fio is located on the test-target and which IO-engines it
+# has available
+[fio]
+bin = "{{ local.env.HOME }}/opt/fio/bin/fio"
+
+[fio.engines.libaio]
+type = "builtin"
+
+[fio.engines.io_uring]
+type = "builtin"
+
+[fio.engines.io_uring_cmd]
+type = "builtin"
+
+[fio.engines.xnvme]
+type = "builtin"
+
+[fio.engines.spdk_nvme]
+path = "/opt/aux/spdk_nvme"
+type = "external_preload"
+
+[fio.engines.spdk_bdev]
+path = "/opt/aux/spdk_bdev"
+type = "external_preload"

--- a/src/cijoe/fio/configs/example_config_default.toml
+++ b/src/cijoe/fio/configs/example_config_default.toml
@@ -1,31 +1,11 @@
-# Declaration of where fio is located on the test-target and which IO-engines it has available
+# Used by: fio.{build,install,check} and by the wrapper for the location of the
+# fio binary
 [fio]
 bin = "{{ local.env.HOME }}/opt/fio/bin/fio"
 
 [fio.repository]
-upstream = "https://github.com/axboe/fio.git"
+remote = "https://github.com/axboe/fio.git"
 path = "{{ local.env.HOME }}/git/fio"
 
 [fio.build]
 prefix = "{{ local.env.HOME }}/opt/fio"
-
-[fio.engines.libaio]
-type = "builtin"
-
-[fio.engines.io_uring]
-type = "builtin"
-
-[fio.engines.io_uring_cmd]
-type = "builtin"
-
-[fio.engines.xnvme]
-path = "/usr/local/lib/x86_64-linux-gnu/libxnvme-fio-engine.so"
-type = "external_dynamic"
-
-[fio.engines.spdk_nvme]
-path = "/opt/aux/spdk_nvme"
-type = "external_preload"
-
-[fio.engines.spdk_bdev]
-path = "/opt/aux/spdk_bdev"
-type = "external_preload"

--- a/src/cijoe/fio/workflows/example_workflow_default.yaml
+++ b/src/cijoe/fio/workflows/example_workflow_default.yaml
@@ -1,8 +1,12 @@
 ---
 doc: |
-  This workflow demonstrates how to use build and install fio via cijoe
+  This workflow demonstrates how to use build and install fio using scripts and
+  workflow defined by cijoe
 
 steps:
+- name: repository_prep
+  uses: core.repository_prep
+
 - name: build
   uses: fio.build
 


### PR DESCRIPTION
The example configuration file is split into build and benchmark sections to simplify examples, ensuring each file contains only entries relevant to the specific use case.

Additional work is required on the package. This change exercises the build, install, and check scripts, but the more complex fio-wrapper script is not yet covered and the documentation needs updating as well.