### PR TITLE
Add coverage dependencies to docker container

### DIFF
--- a/.github/cijoe-docker/Dockerfile
+++ b/.github/cijoe-docker/Dockerfile
@@ -85,7 +85,9 @@ ENV PIPX_HOME=/root/.local/pipx
 ENV PATH=/root/.local/bin::$PATH
 
 # Install cijoe itself
-RUN pipx install cijoe==$CIJOE_VERSION
+RUN pipx install cijoe==$CIJOE_VERSION \
+	pipx inject cijoe coverage --include-apps --force \
+	pipx inject cijoe pytest-cov --include-deps --force
 
 #
 # Modified SSH Configuration, this is done enable the use of ssh to localhost


### PR DESCRIPTION
This pull request adds the two python packages "coverage" and "pytest coverage" to the dockerfile.

These packages are added to the docker container so that it is not needed to be explicitly installed in the github action workflows.