### PR TITLE
Expand testing of cijoe package; qemu

### DIFF
--- a/.github/workflows/cijoe_packages.yml
+++ b/.github/workflows/cijoe_packages.yml
@@ -29,7 +29,9 @@ jobs:
         - core.default
         - fio.default
         - linux.default
+        - qemu.bootimage
         - qemu.build
+        - qemu.cloudinit
         - system_imaging.default
         python-version: ['3.12']
 

--- a/.github/workflows/cijoe_packages.yml
+++ b/.github/workflows/cijoe_packages.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-    - "cijoe_pkg_*"
+    - "main"
     tags:
     - "v*"
 

--- a/src/cijoe/core/selftest/test_cli_example.py
+++ b/src/cijoe/core/selftest/test_cli_example.py
@@ -1,0 +1,23 @@
+def test_cli_example_emit_listing(cijoe):
+    err, _ = cijoe.run("cijoe --example")
+    assert not err
+
+
+def test_cli_example_emit_specific(cijoe, tmp_path):
+    err, state = cijoe.run("cijoe --example")
+    assert not err
+
+    examples = [line.strip() for line in state.output().splitlines()]
+    for example in examples:
+        err, state = cijoe.run(f"cijoe --example {example}", cwd=tmp_path)
+        assert not err
+
+
+def test_cli_example_emit_all_in_package(cijoe, tmp_path):
+    err, state = cijoe.run("cijoe --example")
+    assert not err
+
+    examples = [line.strip() for line in state.output().splitlines()]
+    for pkg_name in list(set([line.split(".")[0] for line in examples])):
+        err, state = cijoe.run(f"cijoe --example {pkg_name}", cwd=tmp_path)
+        assert not err

--- a/src/cijoe/qemu/configs/example_config_bootimage.toml
+++ b/src/cijoe/qemu/configs/example_config_bootimage.toml
@@ -2,6 +2,10 @@
 # https://www.paramiko.org/ This is common CIJOE infrastructure
 #
 # Used by: cijoe.run() / cijoe.get() / cijoe.put()
+# The SSH options are passed verbatim to paramiko; see
+# https://www.paramiko.org/ This is common CIJOE infrastructure
+#
+# Used by: cijoe.run() / cijoe.get() / cijoe.put()
 [cijoe.transport.qemu_guest]
 username = "root"
 password = "root"

--- a/src/cijoe/qemu/configs/example_config_cloudinit.toml
+++ b/src/cijoe/qemu/configs/example_config_cloudinit.toml
@@ -1,0 +1,60 @@
+# The SSH options are passed verbatim to paramiko; see
+# https://www.paramiko.org/ This is common CIJOE infrastructure
+#
+# Used by: cijoe.run() / cijoe.get() / cijoe.put()
+# The SSH options are passed verbatim to paramiko; see
+# https://www.paramiko.org/ This is common CIJOE infrastructure
+#
+# Used by: cijoe.run() / cijoe.get() / cijoe.put()
+[cijoe.transport.qemu_guest]
+username = "root"
+password = "root"
+hostname = "localhost"
+port = 4200
+
+[cijoe.workflow]
+fail_fast=true
+
+# Used by: the qemu.*.py scripts
+[qemu]
+# Uncomment this, to use a version of qemu build from source and installed in a
+# non-conventional location
+#system_bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-x86_64"
+system_bin = "qemu-system-x86_64"
+img_bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-img"
+default_guest = "bullseye_amd64"
+
+# Used by: qemu.guest_start.py and qemu.guest_kill.py
+[qemu.guests.bullseye_amd64]
+path = "{{ local.env.HOME }}/guests/debian-bullseye-amd64"
+
+# Used by: qemu.guest_start.py (and qemu.guest_start_nvme.py)
+system_args.kwa = {cpu = "host", smp = 4, m = "6G", accel = "kvm"}
+
+# Raw arguments: passed without modification to qemu-system-{arch}
+system_args.raw = """\
+-M "type=q35,kernel_irqchip=split" \
+-device "intel-iommu,pt=on,intremap=on" \
+"""
+#
+# Managed by qemu.guest_start.py, expands into longer system-arguments
+#
+
+# Setup ssh forward from host to guest
+system_args.tcp_forward = {host = 4200, guest = 22}
+
+# This shares the given folder with the guest via 9p, the configuration example
+# below shares your home folder, if you do not want this, then comment it out
+system_args.host_share = "{{ local.env.HOME }}"
+
+# Used by: qemu.guest_init_using_bootimage.py
+init_using_bootimage.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/debian-bullseye-amd64.qcow2"
+init_using_bootimage.url_checksum = "https://refenv.fra1.digitaloceanspaces.com/boot_images/debian-bullseye-amd64.qcow2.sha256"
+init_using_bootimage.img = "{{ local.env.HOME }}/images/boot_images/debian-bullseye-amd64.qcow2"
+
+# Used by: qemu.guest_init_using_cloudinit.py
+init_using_cloudinit.url = "https://cloud.debian.org/images/cloud/bullseye/daily/latest/debian-11-generic-amd64-daily.qcow2"
+init_using_cloudinit.url_checksum = "https://cloud.debian.org/images/cloud/bullseye/daily/latest/SHA512SUMS"
+init_using_cloudinit.img = "{{ local.env.HOME }}/images/cloudinit/debian-11-generic-amd64-daily.qcow2"
+init_using_cloudinit.meta = "{{ resources.auxiliary['qemu.cloudinit-debian-meta'] }}"
+init_using_cloudinit.user = "{{ resources.auxiliary['qemu.cloudinit-debian-user-amd64'] }}"

--- a/src/cijoe/qemu/scripts/qemu_system_version.py
+++ b/src/cijoe/qemu/scripts/qemu_system_version.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """
-Run qemu-system version
-=======================
+Determine version of qemu-img and system-bins in use by qemu-guests
+===================================================================
 
-This script records the qemu-system version in the logs, ensuring the version used by
-the qemu.wrapper is always available for inspection in reports.
+This script records the qemu-img version in the logs, ensuring the version used by the
+qemu.wrapper is always available for inspection in reports. Additionally, then it goes
+through the list of qemu.guests, to retrieve the version of the system bins that they
+are using.
 
 Retargetable: False
 -------------------
@@ -12,12 +14,22 @@ Retargetable: False
 import errno
 from pathlib import Path
 
-from cijoe.qemu.wrapper import qemu_system
+from cijoe.qemu.wrapper import qemu_img, qemu_system
 
 
 def main(args, cijoe, step):
     """Install qemu"""
 
-    err, _ = qemu_system(cijoe, "--version")
+    errors = []
 
-    return err
+    err, _ = qemu_img(cijoe, "--version")
+    errors.append(err)
+
+    err, _ = qemu_system(cijoe, "--version")
+    errors.append(err)
+
+    for err in errors:
+        if err:
+            return err
+
+    return 0

--- a/src/cijoe/qemu/workflows/example_workflow_bootimage.yaml
+++ b/src/cijoe/qemu/workflows/example_workflow_bootimage.yaml
@@ -1,0 +1,25 @@
+---
+doc: |
+  This workflow demonstrates how to use qemu via cijoe in steps of
+
+  * Provision a guest using a cloud-init image
+  * Start the guest
+  * Run a command within the guest (via SSH)
+  * Stop the guest again
+
+  This is done via scripts, which in turn are utilizing helper-functions from
+  cijoe.qemu.wrapper.
+
+steps:
+- name: bootimage
+  uses: qemu.guest_init_using_bootimage
+
+- name: start
+  uses: qemu.guest_start
+
+- name: check
+  run: |
+    hostname
+
+- name: kill
+  uses: qemu.guest_kill

--- a/src/cijoe/qemu/workflows/example_workflow_cloudinit.yaml
+++ b/src/cijoe/qemu/workflows/example_workflow_cloudinit.yaml
@@ -14,16 +14,6 @@ steps:
 - name: cloudinit
   uses: qemu.guest_init_using_cloudinit
 
-#
-# In case you do not want to use cloud-init and you already have a bootable
-# image, then comment the 'cloudinit' step above, and uncomment the 'bootimg'
-# step below.
-# Also, remember to adjust the config section [qemu.guest.init_using_image] to
-# point to where the bootable image can be downloaded or copied from.
-#
-#- name: bootimg
-#  uses: qemu.guest_init_using_bootimage
-
 - name: start
   uses: qemu.guest_start
 


### PR DESCRIPTION
The cloud-init and bootimage initialization examples were not being tested. This PR addresses that by enabling them through two explicit examples.