### PR TITLE
refactor(cli): improve example discovery and organization

### DIFF
--- a/.github/workflows/cijoe_packages.yml
+++ b/.github/workflows/cijoe_packages.yml
@@ -25,7 +25,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        usage_example: ['fio', 'system_imaging', 'qemu.build', 'linux']
+        usage_example:
+        - fio.default
+        - linux.default
+        - qemu.build
+        - system_imaging.default
         python-version: ['3.12']
 
     steps:
@@ -52,6 +56,7 @@ jobs:
 
     - name: Run it!
       run: |
+        cd cijoe-example-${{ matrix.usage_example }}
         cijoe --monitor -l
 
     - name: Upload report
@@ -59,5 +64,5 @@ jobs:
       uses: actions/upload-artifact@v4.3.0
       with:
         name: report-cijoe_packages-${{ matrix.usage_example }}
-        path: cijoe-output/*
+        path: cijoe-example-${{ matrix.usage_example }}/cijoe-output/*
         if-no-files-found: error


### PR DESCRIPTION
The previous method of discovering examples was cumbersome. Users had to run `cijoe --resources` and manually search for files with "example" in their names, then piece together configuration files, workflows, and scripts.

This refactor changes the behavior of the `cijoe --example` command to make example discovery more intuitive:

- Running `cijoe --example` now lists all available examples.
- Running `cijoe --example qemu` outputs all examples specific to the `qemu` package.
- Running `cijoe --example qemu.build` outputs only the `qemu.build` example.

Additionally, examples are now output into a subfolder of the current working directory in the format:

  cijoe-example-<pkg_name>.<example>

This improves usability and streamlines access to examples.

This fixes https://github.com/refenv/cijoe/issues/131