### PR TITLE
fix(docker): remove errornoeous `--include-deps` flag from pipx install

### DIFF
--- a/.github/cijoe-docker/Dockerfile
+++ b/.github/cijoe-docker/Dockerfile
@@ -87,7 +87,7 @@ ENV PATH=/root/.local/bin::$PATH
 # Install cijoe itself
 RUN pipx install cijoe==$CIJOE_VERSION \
 	pipx inject cijoe coverage --include-apps --force \
-	pipx inject cijoe pytest-cov --include-deps --force
+	pipx inject cijoe pytest-cov --force
 
 #
 # Modified SSH Configuration, this is done enable the use of ssh to localhost


### PR DESCRIPTION
The `--include-deps` flag was mistakenly added to the pip install(pipx) command for the pytest-cov package