### PR TITLE
Issue 128: Update docker container to add myrunner user

### DIFF
--- a/.github/cijoe-docker/Dockerfile
+++ b/.github/cijoe-docker/Dockerfile
@@ -25,6 +25,9 @@ FROM debian:bookworm
 
 WORKDIR /opt
 
+# User for running GHA Runner
+RUN useradd -ms /bin/bash devuser
+
 RUN apt-get -qy update && \
 	apt-get -qy \
 	-o "Dpkg::Options::=--force-confdef" \


### PR DESCRIPTION
This user is needed for the GHA runner example run. The corresponding PR for this(#148)  needs this to be merged and
run on the main branch before the aforementioned PR will run successfully.