### PR TITLE
 feat(cli): add subparsers for workflows and scripts 

### DIFF
--- a/docs/source/200_quickstart.cmd
+++ b/docs/source/200_quickstart.cmd
@@ -8,6 +8,6 @@ cijoe --example
 cijoe --example core.default
 
 # Execute the workflow
-cijoe --workflow cijoe-example-core.default/cijoe-workflow.yaml \
+cijoe cijoe-example-core.default/cijoe-workflow.yaml \
 	--config cijoe-example-core.default/cijoe-config.toml
 

--- a/docs/source/300_lint.cmd
+++ b/docs/source/300_lint.cmd
@@ -1,4 +1,4 @@
 # Check format of workflow and verify existance of the scripts used
 cijoe --integrity-check \
 	--config cijoe-example-core.default/cijoe-config.toml \
-	--workflow cijoe-example-core.default/cijoe-workflow.yaml
+	cijoe-example-core.default/cijoe-workflow.yaml

--- a/docs/source/420_usage_workflow_all.cmd
+++ b/docs/source/420_usage_workflow_all.cmd
@@ -1,4 +1,3 @@
 # Run the workflow
-cijoe \
- --workflow cijoe-example-core.default/cijoe-workflow.yaml \
+cijoe cijoe-example-core.default/cijoe-workflow.yaml \
  --config cijoe-example-core.default/cijoe-config.toml

--- a/docs/source/450_usage_workflow_subset.cmd
+++ b/docs/source/450_usage_workflow_subset.cmd
@@ -1,5 +1,4 @@
 # Run a subset of the steps in the workflow
-cijoe \
- --workflow cijoe-example-core.default/cijoe-workflow.yaml \
+cijoe cijoe-example-core.default/cijoe-workflow.yaml \
  --config cijoe-example-core.default/cijoe-config.toml \
  inline_commands

--- a/docs/source/scripts/index.rst
+++ b/docs/source/scripts/index.rst
@@ -167,14 +167,3 @@ available, how to add it? This can be done by **injecting** it into the
 **cijoe** venv provided by **pipx**. Here is an example, of adding matplotlib:
 
 .. literalinclude:: ../100_inject.cmd
-
-Running a sequence of **cijoe** scripts
----------------------------------------
-
-If you have created multiple **cijoe** scripts that needs to be run
-sequentially, you can do so by adding all scripts as arguments to the **cijoe**
-command.
-
-.. code-block:: python
-
-   cijoe path/to/cijoe-script-A.py path/to/script-B.py [...]

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -61,10 +61,10 @@ Which yields the following output:
 Search Paths
 ============
 
-The :ref:`sec-usage-cli` for config-files (``--c / --config``) and workflows
-(``-w / --workflow``) by default search for files named ``cijoe-config.toml``
-and ``cijoe-workflow.yaml``, respectfully. These files are searched for, in
-order, in the following locations:
+The :ref:`sec-usage-cli` for the positional argument, and config-files 
+(``--c / --config``) and workflows (``-w / --workflow``) by default search for files
+named ``cijoe-workflow.yaml`` and ``cijoe-config.toml``, respectfully. These files
+are searched for, in order, in the following locations:
 
 ``$PWD``
    In your current working directory
@@ -102,5 +102,5 @@ CIJOE_DEFAULT_CONFIG
     ``-c/--config`` argument.
 
 CIJOE_DEFAULT_WORKFLOW
-    When set, the value will be used as the default for the command-line 
-    ``-w/--workflow`` argument.
+    When set, the value will be used as the default for the positional
+    command-line argument.

--- a/src/cijoe/core/scripts/example_script_default.py
+++ b/src/cijoe/core/scripts/example_script_default.py
@@ -6,7 +6,8 @@ The script is a modified "Hello, World!" example. It repeatedly prints a message
 number of times and allows parameterization of the message content.
 
 The purpose of this script is to demonstrate how to run commands and supply input to the
-script using a configuration file, environment variables, and workflow step arguments.
+script using a configuration file, environment variables, command-line arguments and 
+workflow step arguments.
 
 An example of using the core infrastructure of cijoe:
 
@@ -33,16 +34,26 @@ them yourself.
 """
 
 import logging as log
-from argparse import Namespace
+from argparse import ArgumentParser, Namespace
 
 from cijoe.core.command import Cijoe
+
+
+def add_args(parser: ArgumentParser):
+    """Optional function for defining command-line arguments for this script"""
+    parser.add_argument(
+        "--message", type=str, default=None, help="The message to be printed"
+    )
 
 
 def main(args: Namespace, cijoe: Cijoe, step: dict):
     """Entry-point of the cijoe-script"""
 
-    # Grab message from configuration-file
-    message = cijoe.getconf("example.message", "Hello World!")
+    # Grab message from command-line arguments, if none is given, grab it from
+    # the configuration-file
+    message = getattr(args, "message", None) or cijoe.getconf(
+        "example.message", "Hello World!"
+    )
 
     # When executed via workflow, grab the step-argument
     repeat = int(step.get("with", {}).get("repeat", 1))

--- a/tests/core/test_workflow.py
+++ b/tests/core/test_workflow.py
@@ -45,9 +45,8 @@ def test_workflow_lint_valid_workflow(tmp_path):
     result = subprocess.run(
         [
             "cijoe",
-            "--integrity-check",
-            "--workflow",
             str(workflow_file),
+            "--integrity-check",
             "--config",
             str(config_path),
         ],
@@ -72,9 +71,8 @@ def test_workflow_lint_invalid_step_name(tmp_path):
     result = subprocess.run(
         [
             "cijoe",
-            "--integrity-check",
-            "--workflow",
             str(workflow_file),
+            "--integrity-check",
             "--config",
             str(config_path),
         ],
@@ -104,10 +102,9 @@ def test_workflow_report_command_ordering(tmp_path):
     result = subprocess.run(
         [
             "cijoe",
+            str(workflow_file),
             "--output",
             str(output_path),
-            "--workflow",
-            str(workflow_file),
             "--config",
             str(config_path),
         ],


### PR DESCRIPTION
This commit changes the way cijoe scripts and workflows are run. The interface is now `cijoe {workflow path|script name|script path} [...options]`.

If the positional arg is referencing a stand-alone script, additional cli args can be defined by adding a function to the cijoe script file of the form `add_args(parser: ArgumentParser)`. This will allow us to remove the `step` argument in the cijoe script main function at a later point.

If positional arg is referencing a workflow file, additional positional arguments will be treated as step arguments, defining which steps in the workflow will be run.