### PR TITLE
Boolean script arguments

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,7 @@ html_context = {
 
 extlinks = {
     "ansible": ("https://www.ansible.com/%s", None),
+    "argparse": ("https://docs.python.org/3/library/argparse.html%s", None),
     "chef": ("https://www.chef.io/%s", None),
     "expect": ("https://en.wikipedia.org/wiki/Expect%s", None),
     "fabric": ("https://www.fabfile.org/%s", None),

--- a/docs/source/scripts/index.rst
+++ b/docs/source/scripts/index.rst
@@ -150,6 +150,47 @@ example, if the environment variable ``EXAMPLE_MAX_VALUE`` is set, its value
 will be used instead of the value specified in the configuration file.
 
 
+.. _sec-resources-scripts-arguments:
+
+Script Arguments
+================
+
+Some **cijoe** scripts have command-line arguments, which are evaluated with the 
+:argparse:`argparse<>` library. These arguments are added by defining a function 
+`add_args(parser: argparse.ArgumentParser)` in the **cijoe** script file.
+
+.. code-block:: python
+
+   from argparse import ArgumentParser
+
+   def add_args(parser: argparse.ArgumentParser):
+      parser.add_argument(
+        "--message",
+        type=str,
+      )
+
+Note that the :argparse:`argparse documentation<#type>` advices against using the 
+``bool()`` function as type converter. The **cijoe** scripts that has boolean 
+cli-arguments use the ``choices`` parameter and a custom store action to convert
+the strings ``"true"`` and ``"false"`` to ``True`` and ``False``, respectively.
+
+.. code-block:: python
+
+   from argparse import ArgumentParser, _StoreAction
+
+   def add_args(parser: ArgumentParser):
+      class StringToBoolAction(_StoreAction):
+         def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, values == "true")
+
+      parser.add_argument(
+         "--run_local",
+         choices=["true", "false"],
+         default=True,
+         action=StringToBoolAction
+      )
+
+
 .. _sec-resources-scripts-python-pkgs:
 
 Adding Python packages

--- a/docs/source/testrunner/index.rst
+++ b/docs/source/testrunner/index.rst
@@ -52,7 +52,7 @@ inserted as a step with arguments like below:
      uses: core.testrunner
      with:
        args: '-k "filtering" my_tests'
-       random-order: false
+       random_order: false
        run_local: false
 
 Here you see three "special" arguments to the testrunner:
@@ -73,7 +73,7 @@ args
   that the latter integrates the **pytest** report into **cijoe**, producing a
   cohesive and standalone report.
 
-random-order
+random_order
   This option **scrambles** the order in which tests are executed. It is
   generally recommended, as it helps reduce inter-test dependencies and
   assumptions about the environment's state.

--- a/src/cijoe/cli/cli.py
+++ b/src/cijoe/cli/cli.py
@@ -338,7 +338,10 @@ def cli_workflow(args):
                     if type(v) is list:
                         arguments += [f"--{k}", *[f"{el}" for el in v]]
                     else:
+                        if type(v) is bool:
+                            v = str(v).lower()
                         arguments += [f"--{k}", f"{v}"]
+
             parser = argparse.ArgumentParser()
             if script.argparser_func:
                 script.argparser_func(parser)

--- a/src/cijoe/cli/cli.py
+++ b/src/cijoe/cli/cli.py
@@ -343,7 +343,7 @@ def cli_workflow(args):
             if script.argparser_func:
                 script.argparser_func(parser)
             script_args = parser.parse_args(arguments)
-            args = argparse.Namespace(**vars(args), **vars(script_args))
+            args = parser.parse_args(arguments, namespace=args)
 
             try:
                 err = script.func(args, cijoe)

--- a/src/cijoe/core/scripts/reporter.py
+++ b/src/cijoe/core/scripts/reporter.py
@@ -19,7 +19,7 @@ report_open: true|false
 
 import logging as log
 import webbrowser
-from argparse import ArgumentParser
+from argparse import ArgumentParser, _StoreAction
 from datetime import datetime
 
 import jinja2
@@ -30,10 +30,15 @@ from cijoe.core.resources import get_resources
 
 
 def add_args(parser: ArgumentParser):
+    class StringToBoolAction(_StoreAction):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, values == "true")
+
     parser.add_argument(
         "--report_open",
-        type=bool,
+        choices=["true", "false"],
         default=False,
+        action=StringToBoolAction,
         help="Whether or not the generated report should be opened (in a browser)",
     )
 

--- a/src/cijoe/core/scripts/testrunner.py
+++ b/src/cijoe/core/scripts/testrunner.py
@@ -61,23 +61,29 @@ use cijoe.run(). Such as tests implemented in Python.
 import copy
 import logging as log
 import uuid
-from argparse import ArgumentParser
+from argparse import ArgumentParser, _StoreAction
 from pathlib import Path
 
 from cijoe.core.resources import dict_to_tomlfile
 
 
 def add_args(parser: ArgumentParser):
+    class StringToBoolAction(_StoreAction):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, values == "true")
+
     parser.add_argument(
         "--run_local",
-        type=bool,
+        choices=["true", "false"],
         default=True,
+        action=StringToBoolAction,
         help="Whether 'pytest' should be executed in same environment as 'cijoe'",
     )
     parser.add_argument(
         "--random_order",
-        type=bool,
+        choices=["true", "false"],
         default=True,
+        action=StringToBoolAction,
         help="Whether the tests should be run in random order",
     )
     parser.add_argument("--args", type=str, help="Additional args given to 'pytest'")
@@ -187,5 +193,4 @@ def pytest_local(args, cijoe):
 
 def main(args, cijoe):
     """Invoke the pytest + cijoe-plugin test-runner"""
-
     return (pytest_local if args.run_local else pytest_remote)(args, cijoe)

--- a/src/cijoe/linux/scripts/build_kdebs.py
+++ b/src/cijoe/linux/scripts/build_kdebs.py
@@ -19,11 +19,15 @@ with.localversion
 """
 
 import logging as log
-from argparse import ArgumentParser
+from argparse import ArgumentParser, _StoreAction
 from pathlib import Path
 
 
 def add_args(parser: ArgumentParser):
+    class StringToBoolAction(_StoreAction):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, values == "true")
+
     parser.add_argument(
         "--local_version",
         type=str,
@@ -32,8 +36,9 @@ def add_args(parser: ArgumentParser):
     )
     parser.add_argument(
         "--run_local",
-        type=bool,
+        choices=["true", "false"],
         default=True,
+        action=StringToBoolAction,
         help="Whether or not to execute in the same environment as 'cijoe'.",
     )
 


### PR DESCRIPTION
A fix for the boolean script arguments that as of now are incorrectly evaluated with the `bool()` function, as both "true" and "false" are evaluated to `True`.

Also commit "fix(core/cli) ......" fixes an error in the way script arguments were added in the workflow, because this approach broke when running the scripts individually with the cli tool