### PR TITLE
fix(qemu/wrapper): add termination logic to qemu wrapper and script 

### DIFF
--- a/src/cijoe/qemu/scripts/guest_wait_for_termination.py
+++ b/src/cijoe/qemu/scripts/guest_wait_for_termination.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Wait for qemu guest termination
+===============================
+
+Note: The script will not fail if the guest does not exist.
+Note: This script does not itself terminate the qemu guest.
+
+Retargetable: False
+-------------------
+"""
+import logging as log
+import time
+from argparse import ArgumentParser
+
+from cijoe.qemu.wrapper import Guest
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--guest_name", type=str, help="Name of the qemu guest.")
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="Amount of seconds to wait for the qemu guest to terminate.",
+    )
+
+
+def main(args, cijoe):
+    """Wait for termination of qemu guest"""
+
+    if "guest_name" not in args:
+        log.error("missing argument: guest_name")
+        return 1
+
+    guest = Guest(cijoe, cijoe.config, args.guest_name)
+
+    start = time.time()
+    err, terminated = guest.wait_for_termination(args.timeout)
+    end = time.time()
+
+    if terminated:
+        log.info(
+            f"Guest({args.guest_name}) terminated gracefully in {end-start} seconds"
+        )
+    else:
+        log.warning(
+            f"Guest({args.guest_name}) was not terminated within {args.timeout} seconds"
+        )
+
+    return err

--- a/src/cijoe/qemu/workflows/example_workflow_guest_aarch64.yaml
+++ b/src/cijoe/qemu/workflows/example_workflow_guest_aarch64.yaml
@@ -39,7 +39,17 @@ steps:
   run: |
     hostname
 
+- name: guest_shutdown
+  run: |
+    sudo shutdown -h now
+
+- name: guest_wait
+  uses: qemu.guest_wait_for_termination
+  with:
+    guest_name: generic-uefi-tcg-aarch64
+    timeout: 60
+
 - name: guest_kill
   uses: qemu.guest_kill
   with:
-    guest_name: generic-bios-kvm-x86_64
+    guest_name: generic-uefi-tcg-aarch64

--- a/src/cijoe/qemu/workflows/example_workflow_guest_x86_64.yaml
+++ b/src/cijoe/qemu/workflows/example_workflow_guest_x86_64.yaml
@@ -39,6 +39,16 @@ steps:
   run: |
     hostname
 
+- name: guest_shutdown
+  run: |
+    sudo shutdown -h now
+
+- name: guest_wait
+  uses: qemu.guest_wait_for_termination
+  with:
+    guest_name: generic-bios-kvm-x86_64
+    timeout: 60
+
 - name: guest_kill
   uses: qemu.guest_kill
   with:


### PR DESCRIPTION
Move the SIGTERM signal logic from the `Guest.kill()` to its own method `Guest.wait_for_termination(timeout)`, which allows us to create a script that gives access to this functionality without force-killing the process

This should be what is needed to fix #82