### PR TITLE
feat(system-imaging): add decompression of cloud images

### DIFF
--- a/.github/workflows/verify_and_publish.yml
+++ b/.github/workflows/verify_and_publish.yml
@@ -127,6 +127,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: tmp install deps
+      run: |
+        apt-get update -y
+        apt-get install libdw-dev -y
+
     - name: Build and install cijoe from source
       run: |
         pipx uninstall cijoe

--- a/src/cijoe/system_imaging/configs/example_config_aarch64.toml
+++ b/src/cijoe/system_imaging/configs/example_config_aarch64.toml
@@ -154,14 +154,16 @@ docker.url = "ghcr.io/refenv/ubuntu-2404-x86_64:main"
 docker.name = "ubuntu-2404-x86_64"
 docker.tag = "example"
 
-#[system-imaging.images.freebsd-x86_64]
-#system_label = "x86_64"
-#
-#cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.ufs.qcow2"
-#cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-freebsd-metadata'] }}"
-#cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-freebsd-userdata'] }}"
-#
-#disk.path = "{{ local.env.HOME }}/system_imaging/disk/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.ufs.qcow2"
+# [system-imaging.images.freebsd-x86_64]
+# system_label = "x86_64"
+
+# cloud.url ="https://download.freebsd.org/releases/VM-IMAGES/14.2-RELEASE/amd64/Latest/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.zfs.qcow2.xz"
+# cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.zfs.qcow2.xz"
+# cloud.decompressed_path = "{{ local.env.HOME }}/system_imaging/cloud/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.zfs.qcow2"
+# cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-freebsd-metadata'] }}"
+# cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-freebsd-userdata'] }}"
+
+# disk.path = "{{ local.env.HOME }}/system_imaging/disk/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.ufs.qcow2"
 
 [system-imaging.images.debian-12-aarch64]
 system_label = "aarch64"

--- a/src/cijoe/system_imaging/configs/example_config_x86_64.toml
+++ b/src/cijoe/system_imaging/configs/example_config_x86_64.toml
@@ -154,14 +154,16 @@ docker.url = "ghcr.io/refenv/ubuntu-2404-x86_64:main"
 docker.name = "ubuntu-2404-x86_64"
 docker.tag = "example"
 
-#[system-imaging.images.freebsd-x86_64]
-#system_label = "x86_64"
-#
-#cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.ufs.qcow2"
-#cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-freebsd-metadata'] }}"
-#cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-freebsd-userdata'] }}"
-#
-#disk.path = "{{ local.env.HOME }}/system_imaging/disk/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.ufs.qcow2"
+# [system-imaging.images.freebsd-x86_64]
+# system_label = "x86_64"
+
+# cloud.url ="https://download.freebsd.org/releases/VM-IMAGES/14.2-RELEASE/amd64/Latest/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.zfs.qcow2.xz"
+# cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.zfs.qcow2.xz"
+# cloud.decompressed_path = "{{ local.env.HOME }}/system_imaging/cloud/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.zfs.qcow2"
+# cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-freebsd-metadata'] }}"
+# cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-freebsd-userdata'] }}"
+
+# disk.path = "{{ local.env.HOME }}/system_imaging/disk/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.ufs.qcow2"
 
 [system-imaging.images.debian-12-aarch64]
 system_label = "aarch64"

--- a/src/cijoe/system_imaging/scripts/dockerimage_from_diskimage.py
+++ b/src/cijoe/system_imaging/scripts/dockerimage_from_diskimage.py
@@ -70,6 +70,7 @@ def dockerimage_from_diskimage(cijoe, image):
             log.error(f"command({command}); err({err})")
             return err
 
+    cijoe.run_local("docker builder prune -a -f")
     cijoe.run_local(f'echo "Needs cleanup!" && find {workdir}')
     cijoe.run_local(
         f'echo "Run with: docker run -it {image["docker"]["name"]}:{image["docker"]["tag"]} bash"'


### PR DESCRIPTION
If cloud images are compressed when downloaded, the user can provide a `decompressed_path` key to the `system-imaging.images.*.cloud` config to indicate that the diskimage_from_cloudimage script should decompress the image after downloading.

If `decompressed_path` is not defined, we assume the image is not compressed.

Should solve #186