### PR TITLE
feat(workflow): add support for multiline commands in "run" key

### DIFF
--- a/src/cijoe/core/resources.py
+++ b/src/cijoe/core/resources.py
@@ -380,7 +380,18 @@ class Workflow(Resource):
                 )
                 return errors
 
-            step["with"]["commands"] = step["run"].splitlines()
+            # non-empty lines in "run"
+            lines: filter[str] = filter(
+                None, map(lambda s: s.strip(), step["run"].splitlines())
+            )
+            step["with"]["commands"] = []
+            buffer = []
+
+            for line in lines:
+                buffer.append(line)
+                if not line.strip().endswith("\\"):
+                    step["with"]["commands"].append("\n".join(buffer))
+                    buffer = []
 
             del step["run"]
 


### PR DESCRIPTION
Before, it was not possible to create a workflow steps like:

```
- name: do_multiple_things 
  run: | 
    cd /some/long/path; \ 
      echo "hello world" > hello.txt; \ 
      cat hello.txt

- name: have_many_arguments 
  run: | 
    ./run_something.sh \ 
      --arg1 value1 \ 
      --arg2 value2 \ 
      --arg2 value3
```

This could end up forcing users to either have very long lines in the workflow, if many arguments had to be given to a tool, *or* have a `cd` prefix for every command in a list of commands if they all had to be executed in a specific directory.

This commit adds multiline support, which follows the syntax of shell scripts where a backslash (\) continues the command onto the next line.

This will fix #199 