### PR TITLE
feat(system_imaging): stage disk images from oras:// artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Sections with "(Upcoming)" describe changes on the roadmap for CIJOE.
 Changes on the `master` branch, from the latest version tag up to and including
 HEAD can be subject to a git rebase.
 
+## 0.9.59 (Upcoming)
+
+Added oras:// support to system-imaging via the diskimage_from_oras script: it
+resolves the artifact reference with withcache, pulls and decompresses the blob,
+and writes a qcow2 to disk.path, skipping the pull when the pinned image is
+already staged.
+
 ## 0.9.2
 
 Added a naive path-sanitizer, switched to using git to "clean", fixed a style-issue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dependencies = [
     "scp",
     "tomli>=1.1.0; python_version < '3.11'",
     "tomli-w",
-    "watchdog"
+    "watchdog",
+    "withcache>=0.6"
 ]
 
 [project.urls]

--- a/src/cijoe/system_imaging/configs/example_config_debian.toml
+++ b/src/cijoe/system_imaging/configs/example_config_debian.toml
@@ -110,6 +110,15 @@ system_args.host_share = "{{ local.env.HOME }}"
 #docker.name = "alpine-3.21-x86_64"
 #docker.tag = "example"
 
+# An image published as an oras:// artifact (e.g. a nosi guest-image). Build it
+# with the "system_imaging.diskimage_from_oras" script, which resolves the
+# reference via withcache, pulls and decompresses the blob, and writes the qcow2
+# to disk.path.
+#[system-imaging.images."ubuntu-2604-x86_64"]
+#system_label = "x86_64"
+#oras.url = "oras://ghcr.io/safl/nosi/ubuntu-2604-headless@sha256:<digest>"
+#disk.path = "{{ local.env.HOME }}/system_imaging/disk/ubuntu-2604-x86_64.qcow2"
+
 [system-imaging.images.debian-12-x86_64]
 system_label = "x86_64"
 

--- a/src/cijoe/system_imaging/scripts/diskimage_from_oras.py
+++ b/src/cijoe/system_imaging/scripts/diskimage_from_oras.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Create a disk image from an oras:// artifact
+============================================
+
+Materializes the qcow2 disk-image for system-imaging entries that declare an
+``oras`` source, such as nosi guest-images published to an OCI registry::
+
+    [system-imaging.images.ubuntu-2604-x86_64]
+    oras.url = "oras://ghcr.io/safl/nosi/ubuntu-2604-headless@sha256:<digest>"
+    disk.path = "{{ local.env.HOME }}/system_imaging/disk/ubuntu-2604-x86_64.qcow2"
+
+oras artifacts have no stable download URL, so the reference is resolved with the
+withcache oras adapter (the anonymous bearer-token flow) to a registry blob URL
+plus an auth header. The blob is pulled with curl, which retries and resumes,
+then decompressed and converted to the qcow2 at ``disk.path``. A withcache curl
+shim, if one is configured in the environment, caches the transfer transparently.
+
+The pull is skipped when the pinned image is already staged, keyed on the content
+digest recorded in a stamp next to the qcow2; bumping the digest in the config
+re-stages.
+
+Restrict which images are built with a case-insensitive fnmatch ``pattern``::
+
+    with:
+      pattern: "ubuntu-2604*"
+
+Retargetable: False
+-------------------
+
+This script only runs on the initiator; it writes to the local filesystem.
+"""
+import errno
+import gzip
+import logging as log
+import tempfile
+from argparse import ArgumentParser
+from fnmatch import fnmatch
+from pathlib import Path
+
+from withcache import oras
+
+from cijoe.qemu.wrapper import qemu_img
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--pattern", type=str, help="Pattern for image names to build")
+
+
+def _curl(cijoe, url: str, headers: dict, dst: Path):
+    """Pull ``url`` to ``dst`` with curl; retries and resumes on failure."""
+
+    hdrs = " ".join(f"-H '{key}: {val}'" for key, val in headers.items())
+    err, _ = cijoe.run_local(
+        f"curl -fL --retry 5 --retry-all-errors -C - {hdrs} -o {dst} '{url}'"
+    )
+    return err
+
+
+def diskimage_from_oras(cijoe, image: dict):
+    """Resolve the oras source, pull it, and convert it to the disk image"""
+
+    if not (oras_src := image.get("oras", {})):
+        return None  # not an oras-sourced image; nothing to do
+    if not (url := oras_src.get("url")):
+        log.error("missing .oras.url entry in configuration file")
+        return errno.EINVAL
+
+    if not (disk := image.get("disk", {})):
+        log.error("missing .disk entry in configuration file")
+        return errno.EINVAL
+    disk_path = Path(disk.get("path"))
+
+    # Skip when the pinned image is already staged; the content digest is kept in
+    # a stamp next to the qcow2 and a digest bump in the config re-stages.
+    digest = oras.parse_ref(url).digest
+    stamp = Path(f"{disk_path}.digest")
+    if (
+        digest
+        and disk_path.exists()
+        and stamp.exists()
+        and stamp.read_text().strip() == digest
+    ):
+        log.info(f"image already staged at {disk_path} ({digest}); skipping pull")
+        return 0
+
+    resolved = oras.resolve_ref(url)
+    disk_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Workdir on disk_path's filesystem; a /tmp overlay may be too small for the
+    # decompressed image.
+    with tempfile.TemporaryDirectory(dir=disk_path.parent) as workdir:
+        blob = Path(workdir) / "image.blob"
+        if err := _curl(cijoe, resolved.blob_url, dict(resolved.headers), blob):
+            log.error(f"curl({resolved.blob_url}): failed")
+            return err
+
+        # gzip-compressed artifacts decompress sparsely (disk images are mostly
+        # zeros); anything else is handed to the converter as-is.
+        with open(blob, "rb") as peek:
+            gzipped = peek.read(2) == b"\x1f\x8b"
+        src, src_fmt = blob, ""
+        if gzipped:
+            src, src_fmt = Path(workdir) / "image.raw", "-f raw "
+            block_size = 1 << 20
+            zero_block = b"\0" * block_size
+            with gzip.open(blob, "rb") as compressed, open(src, "wb") as out:
+                while chunk := compressed.read(block_size):
+                    if len(chunk) == block_size and chunk == zero_block:
+                        out.seek(block_size, 1)
+                    else:
+                        out.write(chunk)
+                out.truncate()
+            blob.unlink(missing_ok=True)
+
+        if err := qemu_img(cijoe, f"convert {src_fmt}{src} -O qcow2 {disk_path}")[0]:
+            log.error(f"qemu-img convert({src} -> {disk_path}): failed")
+            return err
+
+    # Headroom for the guest; cloud-init growpart grows the rootfs at boot.
+    if err := qemu_img(cijoe, f"resize {disk_path} +8G")[0]:
+        log.error(f"qemu-img resize({disk_path}): failed")
+        return err
+
+    stamp.write_text(digest or "")
+    qemu_img(cijoe, f"info {disk_path}")
+    return 0
+
+
+def main(args, cijoe):
+    """Build disk images for system-imaging entries with an oras source"""
+
+    pattern = getattr(args, "pattern", None) or "*"
+
+    if not (images := cijoe.getconf("system-imaging.images", {})):
+        log.error("missing: 'system-imaging.images' in configuration file")
+        return errno.EINVAL
+
+    built = 0
+    for image_name, image in images.items():
+        if not fnmatch(image_name.lower(), pattern.lower()):
+            continue
+        if not image.get("oras"):
+            continue
+
+        log.info(f"building oras image: {image_name}")
+        if err := diskimage_from_oras(cijoe, image):
+            log.error(f"diskimage_from_oras({image_name}): err({err})")
+            return err
+        built += 1
+
+    if not built:
+        log.info(f"no oras-sourced images matched pattern({pattern})")
+
+    return 0

--- a/tests/system_imaging/test_diskimage_from_oras.py
+++ b/tests/system_imaging/test_diskimage_from_oras.py
@@ -1,0 +1,52 @@
+"""Unit tests for the system_imaging.diskimage_from_oras script.
+
+These cover the parts that need neither network nor qemu: the digest-keyed skip
+and the image-selection in ``main``. Any unexpected ``run_local`` fails the test.
+"""
+
+from cijoe.system_imaging.scripts import diskimage_from_oras as mod
+
+DIGEST = "sha256:" + "a" * 64
+REF = f"oras://ghcr.io/safl/nosi/example@{DIGEST}"
+
+
+class FakeCijoe:
+    def __init__(self, conf=None):
+        self._conf = conf or {}
+
+    def getconf(self, key, default=None):
+        return self._conf.get(key, default)
+
+    def run_local(self, cmd):
+        raise AssertionError(f"unexpected run_local: {cmd}")
+
+
+class Args:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def test_skip_when_already_staged(tmp_path):
+    disk = tmp_path / "image.qcow2"
+    disk.write_bytes(b"staged")
+    (tmp_path / "image.qcow2.digest").write_text(DIGEST)
+
+    image = {"oras": {"url": REF}, "disk": {"path": str(disk)}}
+
+    # The stamp matches the pinned digest, so it returns without pulling; the
+    # FakeCijoe asserts if any command is run.
+    assert mod.diskimage_from_oras(FakeCijoe(), image) == 0
+
+
+def test_main_ignores_images_without_oras():
+    images = {"debian": {"cloud": {"url": "x"}, "disk": {"path": "/x"}}}
+    cijoe = FakeCijoe({"system-imaging.images": images})
+
+    # No oras source means nothing is built and no command is run.
+    assert mod.main(Args(pattern="*"), cijoe) == 0
+
+
+def test_main_requires_images_config():
+    import errno
+
+    assert mod.main(Args(pattern="*"), FakeCijoe({})) == errno.EINVAL


### PR DESCRIPTION
cijoe's system-imaging can build a disk image from a cloud image and download a
prebuilt one from a URL, but it cannot consume an image published as an oras://
artifact (an OCI registry blob), which is how the nosi guest-images are shipped.
Such artifacts have no stable download URL, so consumers have each reimplemented
the bearer-token resolution to fetch them.

This adds a diskimage_from_oras script to the system-imaging plugin. For each
system-imaging.images.<name> that declares an oras source, it resolves the
reference with withcache.oras, pulls the blob with curl (retrying and resuming,
which matters against ghcr throttling), decompresses it, and converts it to the
qcow2 at disk.path. The pull is skipped when the pinned image is already staged,
keyed on the content digest. withcache becomes a dependency, so any environment
that has cijoe (including the nosi container) has it too.

Consumers can then drop their own staging scripts and point a
system_imaging.diskimage_from_oras step at the oras reference. Validated with
black, isort, ruff, and mypy, plus unit tests for the digest-keyed skip and the
image selection.
