### PR TITLE
chore: low-risk technical debt pass

### DIFF
--- a/docs/emit.py
+++ b/docs/emit.py
@@ -6,7 +6,6 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from pprint import pprint
 
 from jinja2 import Template
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ html_sidebars = {
     "scripts**": [],
     "testrunner**": [],
     "usage**": [],
-    "workflows**": [],
+    "tasks**": [],
 }
 html_theme_options = {
     "header_links_before_dropdown": 8,

--- a/src/cijoe/core/analyser.py
+++ b/src/cijoe/core/analyser.py
@@ -2,13 +2,7 @@
 """
     Library functions for performance requirements and normalization of metrics
 """
-import copy
-import dataclasses
-import os
 import re
-from typing import List, Tuple
-
-import yaml
 
 from cijoe.core.errors import InvalidRangeError, UnknownUnitError
 

--- a/src/cijoe/core/auxiliary/cijoe-completions
+++ b/src/cijoe/core/auxiliary/cijoe-completions
@@ -60,9 +60,14 @@ _cijoe_completion() {
         fi
     done
 
-    # If no YAML file is provided, use 'cijoe-workflow.yaml' as the default
+    # If no YAML file is provided, use 'cijoe-task.yaml' as the default,
+    # falling back to the legacy 'cijoe-workflow.yaml'.
     if [[ -z "$yaml_file" ]]; then
-        yaml_file="cijoe-workflow.yaml"
+        if [[ -f "cijoe-task.yaml" ]]; then
+            yaml_file="cijoe-task.yaml"
+        else
+            yaml_file="cijoe-workflow.yaml"
+        fi
     fi
 
     # If the YAML file doesn't exist, return without suggestions

--- a/src/cijoe/core/command.py
+++ b/src/cijoe/core/command.py
@@ -2,12 +2,10 @@
 
 """
 
-import errno
 import logging as log
 import os
 import sys
 import time
-import traceback
 from pathlib import Path
 from typing import Any, Union
 

--- a/src/cijoe/core/processing.py
+++ b/src/cijoe/core/processing.py
@@ -5,7 +5,7 @@
 import json
 import time
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 from cijoe.core.misc import ENCODING, sanitize_ident
 from cijoe.core.resources import Task, dict_from_yamlfile

--- a/src/cijoe/core/scripts/cmdrunner.py
+++ b/src/cijoe/core/scripts/cmdrunner.py
@@ -62,7 +62,7 @@ def main(args, cijoe):
         return errno.EINVAL
 
     for cmd in args.commands:
-        err, state = cijoe.run(cmd, transport_name=args.transport)
+        err, _ = cijoe.run(cmd, transport_name=args.transport)
         if err:
             break
 

--- a/src/cijoe/core/scripts/example_script_testrunner.py
+++ b/src/cijoe/core/scripts/example_script_testrunner.py
@@ -1,7 +1,6 @@
 from argparse import Namespace
 
 from cijoe.core.command import Cijoe
-from cijoe.core.scripts.testrunner import pytest_remote
 
 
 def test_hello_world(cijoe: Cijoe):

--- a/src/cijoe/core/scripts/repository_prep.py
+++ b/src/cijoe/core/scripts/repository_prep.py
@@ -30,7 +30,6 @@ Retargetable: True
 ------------------
 """
 
-import errno
 import logging as log
 from argparse import ArgumentParser, _StoreAction
 from pathlib import Path

--- a/src/cijoe/core/tasks/example_task_default.yaml
+++ b/src/cijoe/core/tasks/example_task_default.yaml
@@ -1,15 +1,15 @@
 ---
 doc: |
   This is a task file, it serves as an example on how to run commands and
-  scripts, the structure intentionally mimics that of GitHUB actions, however,
+  scripts, the structure intentionally mimics that of GitHub actions, however,
   the keys you see here are all there is.
 
   Running commands, as you can see below, looks just like running commands in a
-  GitHUB Workflow
+  GitHub Workflow
 
   * Add the 'run' key with a value of multi-line string
 
-  Using scripts, it is similar to that of a GitHUB action
+  Using scripts, it is similar to that of a GitHub action
 
   * Add the 'uses' key with the name of the script
     - packaged scripts have a namespaced name e.g. "my_pkg.my_script"

--- a/src/cijoe/core/transport.py
+++ b/src/cijoe/core/transport.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import paramiko
 from scp import SCPClient
 
-from cijoe.core.misc import ENCODING
 from cijoe.core.resources import Config
 
 

--- a/src/cijoe/linux/null_blk.py
+++ b/src/cijoe/linux/null_blk.py
@@ -39,8 +39,4 @@ def insert(cijoe, config=None):
 def remove(cijoe):
     """Remove the null_blk kernel module"""
 
-    # This can be used when instanttation via SYSPATH, however, commented out as it is
-    # not useful yet.
-    # cijoe.run(f"rmdir {NULLBLK_SYSPATH}/nullb*")
-
     return cijoe.run(f"modprobe -r {NULLBLK_MODULE_NAME}")

--- a/src/cijoe/qemu/wrapper.py
+++ b/src/cijoe/qemu/wrapper.py
@@ -12,15 +12,12 @@
 import errno
 import logging as log
 import os
-import shutil
 import time
 from pathlib import Path
 from pprint import pformat
 from typing import Optional
 
 import psutil
-
-from cijoe.core.misc import download_and_verify
 
 
 def qemu_img(cijoe, args=""):

--- a/src/cijoe/system_imaging/scripts/diskimage_from_cloudimage.py
+++ b/src/cijoe/system_imaging/scripts/diskimage_from_cloudimage.py
@@ -41,7 +41,7 @@ from pathlib import Path
 from pprint import pformat
 
 from cijoe.core.misc import decompress_file, download
-from cijoe.qemu.wrapper import Guest, qemu_img
+from cijoe.qemu.wrapper import Guest
 
 
 def add_args(parser: ArgumentParser):

--- a/src/cijoe/system_imaging/scripts/dockerimage_from_diskimage.py
+++ b/src/cijoe/system_imaging/scripts/dockerimage_from_diskimage.py
@@ -29,7 +29,6 @@ from argparse import ArgumentParser
 from fnmatch import fnmatch
 from pathlib import Path
 
-from cijoe.core.misc import download
 from cijoe.core.resources import get_resources
 
 

--- a/tests/core/test_argparse.py
+++ b/tests/core/test_argparse.py
@@ -1,10 +1,7 @@
-import copy
 import os
 import sys
-from argparse import Namespace
-from pathlib import Path
 
-from cijoe.cli.cli import DEFAULT_CONFIG_FILENAME, DEFAULT_TASK_FILENAME, parse_args
+from cijoe.cli.cli import DEFAULT_TASK_FILENAME, parse_args
 
 TEMPLATE_SCRIPT = """def main(args, cijoe):
     return 0

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import yaml
 
-from cijoe.cli.cli import cli_integrity_check
 from cijoe.core.processing import runlog_from_path
 from cijoe.core.resources import get_resources
 


### PR DESCRIPTION
## Summary

Two scoped cleanup commits.

The first drops 22 unused imports flagged by ruff F401 across `docs/`, `src/`, and `tests/`. None of them were API re-exports, confirmed by grepping for each name across the tree before applying `ruff --fix`. While in the same area, it also fixes an unused `state` destructuring at `src/cijoe/core/scripts/cmdrunner.py:65` (a long-standing pyright warning) and removes a three-line commented-out `rmdir` in `src/cijoe/linux/null_blk.py` whose author note had marked it "not useful yet".

The second resolves three leftover references to "workflow" after the recent rename to "task". The Sphinx sidebar pattern in `docs/source/conf.py` still excluded `workflows**` against a directory that has since become `tasks/`. The example task's header had a "GitHUB" casing typo. The bash completion at `src/cijoe/core/auxiliary/cijoe-completions` only knew the legacy default filename `cijoe-workflow.yaml`, so step-name completion silently failed once a user moved to `cijoe-task.yaml`; it now prefers the new name and falls back to the legacy one for users mid-migration.

Items the survey flagged but were intentionally left out: `src/cijoe/core/analyser.py` (no in-tree callers but possibly external API), the open TODOs in `null_blk.py`, `cli.py`, `testrunner.py`, and the report template, the `tomli`/`tomllib` conditional in `resources.py` (3.10 has neither, so the conditional stays), and every deliberate back-compat shim from the rename.

## Test plan

Confirm `verify_and_publish` is green on this branch and that no test depends on any of the removed imports.