### PR TITLE
chore(configs): bump example distros to Debian 13 and Fedora 44

### DIFF
--- a/.github/workflows/verify_and_publish.yml
+++ b/.github/workflows/verify_and_publish.yml
@@ -206,14 +206,14 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - debian-12
-        - fedora-43
+        - debian-13
+        - fedora-44
         - ubuntu-2404
         - freebsd-14
         architecture:
         - x86_64
         include:
-        - image: debian-12
+        - image: debian-13
           architecture: aarch64
 
     steps:

--- a/src/cijoe/core/configs/example_config_get_put.toml
+++ b/src/cijoe/core/configs/example_config_get_put.toml
@@ -40,7 +40,7 @@ system_args.raw = """\
 #
 # You can uncomment it in your config here, or provide as argument as a task step-argument
 #
-#initialize.diskimage = "debian-12-aarch64"
+#initialize.diskimage = "debian-13-aarch64"
 
 # TCP_FORWARD: Setup ssh forward from host to guest
 #
@@ -59,18 +59,16 @@ system_args.host_share = "{{ local.env.HOME }}"
 
 # SYSTEM_IMAGING: A collection of system images in the form of cloudimages,
 # diskimages, and docker images.
-[system-imaging.images.debian-12-aarch64]
+[system-imaging.images.debian-13-aarch64]
 system_label = "aarch64"
 
-cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-arm64-daily.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-12-generic-aarch64-daily.qcow2"
+cloud.url = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-arm64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-13-generic-aarch64-daily.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-12-aarch64.qcow2"
-disk.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/debian-bookworm-arm64.qcow2"
-disk.url_checksum = "https://refenv.fra1.digitaloceanspaces.com/boot_images/debian-bookworm-arm64.qcow2.sha256"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-13-aarch64.qcow2"
 
-docker.url = "ghcr.io/refenv/debian-12-aarch64:main"
-docker.name = "debian-12-aarch64"
+docker.url = "ghcr.io/refenv/debian-13-aarch64:main"
+docker.name = "debian-13-aarch64"
 docker.tag = "example"

--- a/src/cijoe/core/configs/example_config_testrunner.toml
+++ b/src/cijoe/core/configs/example_config_testrunner.toml
@@ -34,7 +34,7 @@ system_label = "x86_64"
 
 # Name of the system_image to use; see "system_imaging.images"
 # Uncomment here, or set as task-argument when using "qemu.guest_initialize"
-#system_image_name = "debian-12-x86_64"
+#system_image_name = "debian-13-x86_64"
 
 # Keyword arguments: joined onto the form: "-cpu host -smp 4 -m 4" etc.
 system_args.kwa = {cpu = "host", smp = 4, m = "6G", accel = "kvm"}
@@ -62,12 +62,12 @@ system_args.host_share = "{{ local.env.HOME }}"
 # SYSTEM_IMAGING: A collection of system images in the form of cloudimages,
 # diskimages, and docker images.
 
-[system-imaging.images.debian-12-x86_64]
+[system-imaging.images.debian-13-x86_64]
 system_label = "x86_64"
 
-cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-amd64-daily.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-12-generic-amd64-daily.qcow2"
+cloud.url = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-amd64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-13-generic-amd64-daily.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-12-x86_64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-13-x86_64.qcow2"

--- a/src/cijoe/core/tasks/example_task_get_put.yaml
+++ b/src/cijoe/core/tasks/example_task_get_put.yaml
@@ -7,7 +7,7 @@ steps:
   uses: qemu.guest_initialize
   with:
     guest_name: generic-uefi-tcg-aarch64
-    system_image_name: debian-12-aarch64
+    system_image_name: debian-13-aarch64
 
 - name: guest_start
   uses: qemu.guest_start

--- a/src/cijoe/core/tasks/example_task_get_put.yaml
+++ b/src/cijoe/core/tasks/example_task_get_put.yaml
@@ -3,6 +3,11 @@ doc: |
   This task file is an example of how to use core.put and core.get.
 
 steps:
+- name: diskimage_from_cloudimage
+  uses: system_imaging.diskimage_from_cloudimage
+  with:
+    pattern: "debian-13-aarch64"
+
 - name: guest_initialize
   uses: qemu.guest_initialize
   with:

--- a/src/cijoe/core/tasks/example_task_testrunner.yaml
+++ b/src/cijoe/core/tasks/example_task_testrunner.yaml
@@ -10,13 +10,13 @@ steps:
 - name: diskimage_from_cloudimage
   uses: system_imaging.diskimage_from_cloudimage
   with:
-    pattern: "debian-12-x86_64"
+    pattern: "debian-13-x86_64"
 
 - name: guest_initialize
   uses: qemu.guest_initialize
   with:
     guest_name: generic-bios-kvm-x86_64
-    system_image_name: debian-12-x86_64
+    system_image_name: debian-13-x86_64
 
 - name: guest_start
   uses: qemu.guest_start

--- a/src/cijoe/linux/configs/example_config_null_blk.toml
+++ b/src/cijoe/linux/configs/example_config_null_blk.toml
@@ -30,7 +30,7 @@ system_label = "x86_64"
 
 # Name of the system_image to use; see "system_imaging.images"
 # Uncomment here, or set as task-argument when using "qemu.guest_initialize"
-#system_image_name = "debian-12-x86_64"
+#system_image_name = "debian-13-x86_64"
 
 # Keyword arguments: joined onto the form: "-cpu host -smp 4 -m 4" etc.
 system_args.kwa = {cpu = "host", smp = 4, m = "6G", accel = "kvm"}
@@ -74,7 +74,7 @@ system_args.raw = """\
 #
 # You can uncomment it in your config here, or provide as argument as a task step-argument
 #
-#initialize.diskimage = "debian-12-aarch64"
+#initialize.diskimage = "debian-13-aarch64"
 
 # TCP_FORWARD: Setup ssh forward from host to guest
 #
@@ -110,34 +110,34 @@ system_args.host_share = "{{ local.env.HOME }}"
 #docker.name = "alpine-3.21-x86_64"
 #docker.tag = "example"
 
-[system-imaging.images.debian-12-x86_64]
+[system-imaging.images.debian-13-x86_64]
 system_label = "x86_64"
 
-cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-amd64-daily.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-12-generic-amd64-daily.qcow2"
+cloud.url = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-amd64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-13-generic-amd64-daily.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-12-x86_64.qcow2"
-disk.url = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-12-x86_64.qcow2"
-disk.url_checksum = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-12-x86_64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-13-x86_64.qcow2"
+disk.url = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-13-x86_64.qcow2"
+disk.url_checksum = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-13-x86_64.qcow2"
 
-docker.url = "ghcr.io/refenv/debian-12-x86_64:main"
-docker.name = "debian-12-x86_64"
+docker.url = "ghcr.io/refenv/debian-13-x86_64:main"
+docker.name = "debian-13-x86_64"
 docker.tag = "example"
 
-[system-imaging.images.fedora-43-x86_64]
+[system-imaging.images.fedora-44-x86_64]
 system_label = "x86_64"
 
-cloud.url ="https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
+cloud.url ="https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
 
-docker.url = "ghcr.io/refenv/fedora-43-x86_64:main"
-docker.name = "fedora-43-x86_64"
+docker.url = "ghcr.io/refenv/fedora-44-x86_64:main"
+docker.name = "fedora-44-x86_64"
 docker.tag = "example"
 
 [system-imaging.images.ubuntu-2404-x86_64]
@@ -163,18 +163,18 @@ docker.tag = "example"
 #
 #disk.path = "{{ local.env.HOME }}/system_imaging/disk/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.ufs.qcow2"
 
-[system-imaging.images.debian-12-aarch64]
+[system-imaging.images.debian-13-aarch64]
 system_label = "aarch64"
 
-cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-arm64-daily.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-12-generic-aarch64-daily.qcow2"
+cloud.url = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-arm64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-13-generic-aarch64-daily.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-12-aarch64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-13-aarch64.qcow2"
 
-docker.url = "ghcr.io/refenv/debian-12-aarch64:main"
-docker.name = "debian-12-aarch64"
+docker.url = "ghcr.io/refenv/debian-13-aarch64:main"
+docker.name = "debian-13-aarch64"
 docker.tag = "example"
 
 # null_blk

--- a/src/cijoe/linux/tasks/example_task_null_blk.yaml
+++ b/src/cijoe/linux/tasks/example_task_null_blk.yaml
@@ -6,13 +6,13 @@ steps:
 - name: diskimage_from_cloudimage
   uses: system_imaging.diskimage_from_cloudimage
   with:
-    pattern: "debian-12-x86_64"
+    pattern: "debian-13-x86_64"
 
 - name: guest_initialize
   uses: qemu.guest_initialize
   with:
     guest_name: generic-bios-kvm-x86_64
-    system_image_name: debian-12-x86_64
+    system_image_name: debian-13-x86_64
 
 - name: guest_start
   uses: qemu.guest_start

--- a/src/cijoe/qemu/configs/example_config_guest_aarch64.toml
+++ b/src/cijoe/qemu/configs/example_config_guest_aarch64.toml
@@ -30,7 +30,7 @@ system_label = "x86_64"
 
 # Name of the system_image to use; see "system_imaging.images"
 # Uncomment here, or set as task-argument when using "qemu.guest_initialize"
-#system_image_name = "debian-12-x86_64"
+#system_image_name = "debian-13-x86_64"
 
 # Keyword arguments: joined onto the form: "-cpu host -smp 4 -m 4" etc.
 system_args.kwa = {cpu = "host", smp = 4, m = "6G", accel = "kvm"}
@@ -74,7 +74,7 @@ system_args.raw = """\
 #
 # You can uncomment it in your config here, or provide as argument as a task step-argument
 #
-#initialize.diskimage = "debian-12-aarch64"
+#initialize.diskimage = "debian-13-aarch64"
 
 # TCP_FORWARD: Setup ssh forward from host to guest
 #
@@ -110,34 +110,34 @@ system_args.host_share = "{{ local.env.HOME }}"
 #docker.name = "alpine-3.21-x86_64"
 #docker.tag = "example"
 
-[system-imaging.images.debian-12-x86_64]
+[system-imaging.images.debian-13-x86_64]
 system_label = "x86_64"
 
-cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-amd64-daily.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-12-generic-amd64-daily.qcow2"
+cloud.url = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-amd64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-13-generic-amd64-daily.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-12-x86_64.qcow2"
-disk.url = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-12-x86_64.qcow2"
-disk.url_checksum = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-12-x86_64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-13-x86_64.qcow2"
+disk.url = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-13-x86_64.qcow2"
+disk.url_checksum = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-13-x86_64.qcow2"
 
-docker.url = "ghcr.io/refenv/debian-12-x86_64:main"
-docker.name = "debian-12-x86_64"
+docker.url = "ghcr.io/refenv/debian-13-x86_64:main"
+docker.name = "debian-13-x86_64"
 docker.tag = "example"
 
-[system-imaging.images.fedora-43-x86_64]
+[system-imaging.images.fedora-44-x86_64]
 system_label = "x86_64"
 
-cloud.url ="https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
+cloud.url ="https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
 
-docker.url = "ghcr.io/refenv/fedora-43-x86_64:main"
-docker.name = "fedora-43-x86_64"
+docker.url = "ghcr.io/refenv/fedora-44-x86_64:main"
+docker.name = "fedora-44-x86_64"
 docker.tag = "example"
 
 [system-imaging.images.ubuntu-2404-x86_64]
@@ -163,16 +163,16 @@ docker.tag = "example"
 #
 #disk.path = "{{ local.env.HOME }}/system_imaging/disk/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.ufs.qcow2"
 
-[system-imaging.images.debian-12-aarch64]
+[system-imaging.images.debian-13-aarch64]
 system_label = "aarch64"
 
-cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-arm64-daily.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-12-generic-aarch64-daily.qcow2"
+cloud.url = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-arm64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-13-generic-aarch64-daily.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-12-aarch64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-13-aarch64.qcow2"
 
-docker.url = "ghcr.io/refenv/debian-12-aarch64:main"
-docker.name = "debian-12-aarch64"
+docker.url = "ghcr.io/refenv/debian-13-aarch64:main"
+docker.name = "debian-13-aarch64"
 docker.tag = "example"

--- a/src/cijoe/qemu/configs/example_config_guest_x86_64.toml
+++ b/src/cijoe/qemu/configs/example_config_guest_x86_64.toml
@@ -30,7 +30,7 @@ system_label = "x86_64"
 
 # Name of the system_image to use; see "system_imaging.images"
 # Uncomment here, or set as task-argument when using "qemu.guest_initialize"
-#system_image_name = "debian-12-x86_64"
+#system_image_name = "debian-13-x86_64"
 
 # Keyword arguments: joined onto the form: "-cpu host -smp 4 -m 4" etc.
 system_args.kwa = {cpu = "host", smp = 4, m = "6G", accel = "kvm"}
@@ -74,7 +74,7 @@ system_args.raw = """\
 #
 # You can uncomment it in your config here, or provide as argument as a task step-argument
 #
-#initialize.diskimage = "debian-12-aarch64"
+#initialize.diskimage = "debian-13-aarch64"
 
 # TCP_FORWARD: Setup ssh forward from host to guest
 #
@@ -110,34 +110,34 @@ system_args.host_share = "{{ local.env.HOME }}"
 #docker.name = "alpine-3.21-x86_64"
 #docker.tag = "example"
 
-[system-imaging.images.debian-12-x86_64]
+[system-imaging.images.debian-13-x86_64]
 system_label = "x86_64"
 
-cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-amd64-daily.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-12-generic-amd64-daily.qcow2"
+cloud.url = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-amd64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-13-generic-amd64-daily.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-12-x86_64.qcow2"
-disk.url = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-12-x86_64.qcow2"
-disk.url_checksum = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-12-x86_64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-13-x86_64.qcow2"
+disk.url = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-13-x86_64.qcow2"
+disk.url_checksum = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-13-x86_64.qcow2"
 
-docker.url = "ghcr.io/refenv/debian-12-x86_64:main"
-docker.name = "debian-12-x86_64"
+docker.url = "ghcr.io/refenv/debian-13-x86_64:main"
+docker.name = "debian-13-x86_64"
 docker.tag = "example"
 
-[system-imaging.images.fedora-43-x86_64]
+[system-imaging.images.fedora-44-x86_64]
 system_label = "x86_64"
 
-cloud.url ="https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
+cloud.url ="https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
 
-docker.url = "ghcr.io/refenv/fedora-43-x86_64:main"
-docker.name = "fedora-43-x86_64"
+docker.url = "ghcr.io/refenv/fedora-44-x86_64:main"
+docker.name = "fedora-44-x86_64"
 docker.tag = "example"
 
 [system-imaging.images.ubuntu-2404-x86_64]
@@ -163,16 +163,16 @@ docker.tag = "example"
 #
 #disk.path = "{{ local.env.HOME }}/system_imaging/disk/FreeBSD-14.2-RELEASE-amd64-BASIC-CLOUDINIT.ufs.qcow2"
 
-[system-imaging.images.debian-12-aarch64]
+[system-imaging.images.debian-13-aarch64]
 system_label = "aarch64"
 
-cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-arm64-daily.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-12-generic-aarch64-daily.qcow2"
+cloud.url = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-arm64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-13-generic-aarch64-daily.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-12-aarch64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-13-aarch64.qcow2"
 
-docker.url = "ghcr.io/refenv/debian-12-aarch64:main"
-docker.name = "debian-12-aarch64"
+docker.url = "ghcr.io/refenv/debian-13-aarch64:main"
+docker.name = "debian-13-aarch64"
 docker.tag = "example"

--- a/src/cijoe/qemu/tasks/example_task_guest_aarch64.yaml
+++ b/src/cijoe/qemu/tasks/example_task_guest_aarch64.yaml
@@ -22,13 +22,13 @@ steps:
 - name: diskimage_from_cloudimage
   uses: system_imaging.diskimage_from_cloudimage
   with:
-    pattern: "debian-12-aarch64"
+    pattern: "debian-13-aarch64"
 
 - name: guest_initialize
   uses: qemu.guest_initialize
   with:
     guest_name: generic-uefi-tcg-aarch64
-    system_image_name: debian-12-aarch64
+    system_image_name: debian-13-aarch64
 
 - name: guest_start
   uses: qemu.guest_start

--- a/src/cijoe/qemu/tasks/example_task_guest_x86_64.yaml
+++ b/src/cijoe/qemu/tasks/example_task_guest_x86_64.yaml
@@ -22,13 +22,13 @@ steps:
 - name: diskimage_from_cloudimage
   uses: system_imaging.diskimage_from_cloudimage
   with:
-    pattern: "debian-12-x86_64"
+    pattern: "debian-13-x86_64"
 
 - name: guest_initialize
   uses: qemu.guest_initialize
   with:
     guest_name: generic-bios-kvm-x86_64
-    system_image_name: debian-12-x86_64
+    system_image_name: debian-13-x86_64
 
 - name: guest_start
   uses: qemu.guest_start

--- a/src/cijoe/system_imaging/configs/example_config_debian.toml
+++ b/src/cijoe/system_imaging/configs/example_config_debian.toml
@@ -30,7 +30,7 @@ system_label = "x86_64"
 
 # Name of the system_image to use; see "system_imaging.images"
 # Uncomment here, or set as task-argument when using "qemu.guest_initialize"
-#system_image_name = "debian-12-x86_64"
+#system_image_name = "debian-13-x86_64"
 
 # Keyword arguments: joined onto the form: "-cpu host -smp 4 -m 4" etc.
 system_args.kwa = {cpu = "host", smp = 4, m = "6G", accel = "kvm"}
@@ -74,7 +74,7 @@ system_args.raw = """\
 #
 # You can uncomment it in your config here, or provide as argument as a task step-argument
 #
-#initialize.diskimage = "debian-12-aarch64"
+#initialize.diskimage = "debian-13-aarch64"
 
 # TCP_FORWARD: Setup ssh forward from host to guest
 #
@@ -119,34 +119,34 @@ system_args.host_share = "{{ local.env.HOME }}"
 #oras.url = "oras://ghcr.io/safl/nosi/ubuntu-2604-headless@sha256:<digest>"
 #disk.path = "{{ local.env.HOME }}/system_imaging/disk/ubuntu-2604-x86_64.qcow2"
 
-[system-imaging.images.debian-12-x86_64]
+[system-imaging.images.debian-13-x86_64]
 system_label = "x86_64"
 
-cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-amd64-daily.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-12-generic-amd64-daily.qcow2"
+cloud.url = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-amd64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-13-generic-amd64-daily.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-12-x86_64.qcow2"
-disk.url = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-12-x86_64.qcow2"
-disk.url_checksum = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-12-x86_64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-13-x86_64.qcow2"
+disk.url = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-13-x86_64.qcow2"
+disk.url_checksum = "https://cijoe-system-imaging.s3.eu-central-003.backblazeb2.com/disk/debian-13-x86_64.qcow2"
 
-docker.url = "ghcr.io/refenv/debian-12-x86_64:main"
-docker.name = "debian-12-x86_64"
+docker.url = "ghcr.io/refenv/debian-13-x86_64:main"
+docker.name = "debian-13-x86_64"
 docker.tag = "example"
 
-[system-imaging.images.fedora-43-x86_64]
+[system-imaging.images.fedora-44-x86_64]
 system_label = "x86_64"
 
-cloud.url ="https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
+cloud.url ="https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
 
-docker.url = "ghcr.io/refenv/fedora-43-x86_64:main"
-docker.name = "fedora-43-x86_64"
+docker.url = "ghcr.io/refenv/fedora-44-x86_64:main"
+docker.name = "fedora-44-x86_64"
 docker.tag = "example"
 
 [system-imaging.images.ubuntu-2404-x86_64]
@@ -173,16 +173,16 @@ cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-freebsd-
 
 disk.path = "{{ local.env.HOME }}/system_imaging/disk/freebsd_14.2_x86_64.qcow2"
 
-[system-imaging.images.debian-12-aarch64]
+[system-imaging.images.debian-13-aarch64]
 system_label = "aarch64"
 
-cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-arm64-daily.qcow2"
-cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-12-generic-aarch64-daily.qcow2"
+cloud.url = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-arm64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/debian-13-generic-aarch64-daily.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
 
-disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-12-aarch64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/debian-13-aarch64.qcow2"
 
-docker.url = "ghcr.io/refenv/debian-12-aarch64:main"
-docker.name = "debian-12-aarch64"
+docker.url = "ghcr.io/refenv/debian-13-aarch64:main"
+docker.name = "debian-13-aarch64"
 docker.tag = "example"


### PR DESCRIPTION
## Summary

Rolls the example configs and the `test_config_images` CI matrix forward to Debian 13 (trixie) and Fedora 44, both currently the latest stable from their respective vendors. Ubuntu 24.04 LTS and FreeBSD 14 are left as-is; Ubuntu noble is still the active LTS and the FreeBSD URL is a credentialed mirror that needs separate attention.

Mechanical replacements across 12 files: `debian-12-{x86_64,aarch64}` -> `debian-13-*` (including the `bookworm` -> `trixie` URL path and `debian-12-generic-amd64-daily.qcow2` filename change) and `fedora-43-x86_64` -> `fedora-44-x86_64` (including the cloud-image filename bump from `Fedora-Cloud-Base-Generic-43-1.6` to `Fedora-Cloud-Base-Generic-44-1.7`, the patch level published with the new release). Cloud-image URLs verified via curl HEAD; both return 200.

One judgement call: `src/cijoe/core/configs/example_config_get_put.toml` dropped its `disk.url`/`disk.url_checksum` shortcut for `debian-13-aarch64`. refenv only hosts a `debian-bookworm-arm64` mirror under `refenv.fra1.digitaloceanspaces.com`, with no trixie variant available, and `disk.url` is only a cache shortcut on top of `cloud.url` anyway. The other `disk.url` entries point at `cijoe-system-imaging.s3...backblazeb2.com` paths that already 404 for both debian-12 and debian-13 (pre-existing dead URLs), so they were left in the diff for shape consistency; the workflow falls back to `cloud.url` regardless.

## Test plan

Watch `test_config_images (debian-13, x86_64)`, `test_config_images (debian-13, aarch64)` and `test_config_images (fedora-44, x86_64)` go green on this PR. Confirm the `examples` jobs that exercise QEMU guests (`core.get_put`, `core.testrunner`, `qemu.guest_*`, `linux.null_blk`) still pass with the new image names. Re-run if the cloud.debian.org mirror flakes mid-download (the same flake that hit the v0.9.60 tag run is unrelated to the version bump).
